### PR TITLE
Add hostname to config values of the chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The following table lists the useful configurable parameters of the Langfuse cha
 | `langfuse.nextauth.secret` | Used to encrypt the NextAuth.js JWT, and to hash email verification tokens. | `changeme` |
 | `langfuse.salt` | Salt for API key hashing | `changeme` |
 | `langfuse.telemetryEnabled` | Weither or not to enable telemetry (reports basic usage statistics of self-hosted instances to a centralized server). | `true` |
-| `langfuse.additionalEnv` | Dict that allow addition of additional env variables | `[]` |
+| `langfuse.additionalEnv` | Dict that allow addition of additional env variables, see [documentation](https://langfuse.com/docs/deployment/self-host#configuring-environment-variables) for details. | `[]` |
 | `langfuse.hostname` | Hostname of the Langfuse application | `0.0.0.0` |
 | `service.type` | Change the default k8s service type deployed with the application | `ClusterIP` |
 | `service.additionalLabels` | Add additional annotations to the service deployed with the application | `[]` |

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The following table lists the useful configurable parameters of the Langfuse cha
 | `langfuse.salt` | Salt for API key hashing | `changeme` |
 | `langfuse.telemetryEnabled` | Weither or not to enable telemetry (reports basic usage statistics of self-hosted instances to a centralized server). | `true` |
 | `langfuse.additionalEnv` | Dict that allow addition of additional env variables | `[]` |
+| `langfuse.hostname` | Hostname of the Langfuse application | `0.0.0.0` |
 | `service.type` | Change the default k8s service type deployed with the application | `ClusterIP` |
 | `service.additionalLabels` | Add additional annotations to the service deployed with the application | `[]` |
 | `ingress.enabled` | Enable ingress for the application | `false` |

--- a/charts/langfuse/templates/deployment.yaml
+++ b/charts/langfuse/templates/deployment.yaml
@@ -36,6 +36,8 @@ spec:
           env:
             - name: NODE_ENV
               value: {{ .Values.langfuse.nodeEnv | quote }}
+            - name: HOSTNAME
+              value: {{ .Values.langfuse.hostName | quote }}
             - name: DATABASE_USERNAME
               value: {{ .Values.postgresql.auth.username | quote }}
             - name: DATABASE_PASSWORD

--- a/charts/langfuse/templates/deployment.yaml
+++ b/charts/langfuse/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
             - name: NODE_ENV
               value: {{ .Values.langfuse.nodeEnv | quote }}
             - name: HOSTNAME
-              value: {{ .Values.langfuse.hostName | quote }}
+              value: {{ .Values.langfuse.hostname | quote }}
             - name: DATABASE_USERNAME
               value: {{ .Values.postgresql.auth.username | quote }}
             - name: DATABASE_PASSWORD

--- a/charts/langfuse/values.yaml
+++ b/charts/langfuse/values.yaml
@@ -11,7 +11,7 @@ fullnameOverride: ""
 
 langfuse:
   nodeEnv: production
-  hostName: 0.0.0.0
+  hostname: 0.0.0.0
   nextauth:
     url: http://localhost:3000
     secret: changeme

--- a/charts/langfuse/values.yaml
+++ b/charts/langfuse/values.yaml
@@ -11,6 +11,7 @@ fullnameOverride: ""
 
 langfuse:
   nodeEnv: production
+  hostName: 0.0.0.0
   nextauth:
     url: http://localhost:3000
     secret: changeme

--- a/examples/langfuse-configmap.yaml
+++ b/examples/langfuse-configmap.yaml
@@ -4,6 +4,7 @@ metadata:
   name: langfuse-configmap
 data:
   langfuse-node-env: production
+  langfuse-host-name: 0.0.0.0
   langfuse-db-url: postgresql://postgres:postgres@db:5432/postgres
   langfuse-nextauth-url: http://localhost:3000
   langfuse-nextauth-secret: mysecret

--- a/examples/langfuse-configmap.yaml
+++ b/examples/langfuse-configmap.yaml
@@ -4,7 +4,7 @@ metadata:
   name: langfuse-configmap
 data:
   langfuse-node-env: production
-  langfuse-host-name: 0.0.0.0
+  langfuse-hostname: 0.0.0.0
   langfuse-db-url: postgresql://postgres:postgres@db:5432/postgres
   langfuse-nextauth-url: http://localhost:3000
   langfuse-nextauth-secret: mysecret

--- a/examples/langfuse-deployment.yaml
+++ b/examples/langfuse-deployment.yaml
@@ -24,7 +24,7 @@ spec:
               valueFrom:
                 configMapKeyRef:
                   name: langfuse-configmap
-                  key: langfuse-host-name
+                  key: langfuse-hostname
             - name: DATABASE_URL
               valueFrom:
                 configMapKeyRef:

--- a/examples/langfuse-deployment.yaml
+++ b/examples/langfuse-deployment.yaml
@@ -20,6 +20,11 @@ spec:
                 configMapKeyRef:
                   name: langfuse-configmap
                   key: langfuse-node-env
+            - name: HOSTNAME
+              valueFrom:
+                configMapKeyRef:
+                  name: langfuse-configmap
+                  key: langfuse-host-name
             - name: DATABASE_URL
               valueFrom:
                 configMapKeyRef:


### PR DESCRIPTION
I had to configure the hostname to 0.0.0.0 to be able to reach the langfuse ui outside of my aks cluster with a port-forwarding. I think it makes sense to add hostname as a configurable value in the helm chart.