### PR TITLE
Add Database ValueFrom

### DIFF
--- a/charts/langfuse/Chart.yaml
+++ b/charts/langfuse/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: langfuse
-version: 0.2.1
+version: 0.2.2
 description: Open source LLM engineering platform - LLM observability, metrics, evaluations, prompt management.
 type: application
 keywords:

--- a/charts/langfuse/templates/_helpers.tpl
+++ b/charts/langfuse/templates/_helpers.tpl
@@ -70,6 +70,20 @@ Create the name of the secret for nextauth
 {{- end }}
 
 {{/*
+Create the name of the configmap for nextauth
+*/}}
+{{- define "langfuse.nextauthConfigMapName" -}}
+{{- printf "%s-nextauth" (include "langfuse.fullname" .) -}}
+{{- end }}
+
+{{/*
+Create the name of the secret for salt
+*/}}
+{{- define "langfuse.saltSecretName" -}}
+{{- printf "%s-salt" (include "langfuse.fullname" .) -}}
+{{- end }}
+
+{{/*
 Create the name of the secret for postgresql if we use an external database
 */}}
 {{- define "langfuse.postgresqlSecretName" -}}
@@ -84,5 +98,145 @@ Return PostgreSQL fullname
 {{- include "common.names.dependency.fullname" (dict "chartName" "postgresql" "chartValues" .Values.postgresql "context" $) -}}
 {{- else }}
 {{- printf "%s-postgresql" (include "langfuse.fullname" .) -}}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the postgresqlConfigMapName
+*/}}
+{{- define "langfuse.postgresqlConfigMapName" -}}
+{{- printf "%s-postgresql" (include "langfuse.fullname" .) -}}
+{{- end }}
+
+{{/*
+Create the valueFrom json for DATABASE_HOST
+*/}}
+{{- define "langfuse.postgresql.databaseHost.valueFrom" -}}
+{{- if .Values.postgresql.deploy -}}
+configMapRef:
+  name: {{ include "langfuse.postgresqlConfigMapName" . }}
+  key: postgres-database
+{{- else if .Values.langfuse.postgresql.host.valueFrom -}}
+{{- toYaml .Values.langfuse.postgresql.host.valueFrom }}
+{{- else -}}
+configMapRef:
+  name: {{ include "langfuse.postgresqlConfigMapName" . }}
+  key: postgres-database
+{{- end }}
+{{- end }}
+
+{{/*
+Create the valueFrom json for DATABASE_USERNAME
+*/}}
+{{- define "langfuse.postgresql.auth.username.valueFrom" -}}
+{{- if .Values.postgresql.deploy -}}
+configMapRef:
+  name: {{ include "langfuse.postgresqlConfigMapName" . }}
+  key: postgres-username
+{{- else if .Values.langfuse.postgresql.auth.username.valueFrom -}}
+{{- toYaml .Values.langfuse.postgresql.auth.username.valueFrom }}
+{{- else -}}
+configMapRef:
+  name: {{ include "langfuse.postgresqlConfigMapName" . }}
+  key: postgres-username
+{{- end }}
+{{- end }}
+
+{{/*
+Create the valueFrom json for DATABASE_PASSWORD
+*/}}
+{{- define "langfuse.postgresql.auth.password.valueFrom" -}}
+{{- if .Values.postgresql.deploy -}}
+secretKeyRef:
+  name: {{ include "langfuse.postgresqlSecretName" . }}
+  key: postgres-password
+{{- else if .Values.langfuse.postgresql.auth.password.valueFrom }}
+{{- toYaml .Values.langfuse.postgresql.auth.password.valueFrom }}
+{{- else -}}
+configMapRef:
+  name: {{ include "langfuse.postgresqlSecretName" . }}
+  key: postgres-password
+{{- end }}
+{{- end }}
+
+{{/*
+Create the valueFrom json for DATABASE_NAME
+*/}}
+{{- define "langfuse.postgresql.auth.database.valueFrom" -}}
+{{- if .Values.postgresql.deploy -}}
+configMapRef:
+  name: {{ include "langfuse.postgresqlConfigMapName" . }}
+  key: postgres-database
+{{- else if .Values.langfuse.postgresql.auth.database.valueFrom }}
+{{- toYaml .Values.langfuse.postgresql.auth.database.valueFrom }}
+{{- else -}}
+configMapRef:
+  name: {{ include "langfuse.postgresqlConfigMapName" . }}
+  key: postgres-database
+{{- end }}
+{{- end }}
+
+{{/*
+Create the valueFrom json for SALT
+*/}}
+{{- define "langfuse.salt.valueFrom" -}}
+{{- if .Values.langfuse.salt.valueFrom }}
+{{- toYaml .Values.langfuse.salt.valueFrom }}
+{{- else -}}
+secretKeyRef:
+  name: {{ include "langfuse.saltSecretName" . }}
+  key: salt
+{{- end }}
+{{- end }}
+
+{{/*
+Create the valueFrom json for DIRECT_URL
+*/}}
+{{- define "langfuse.postgresql.directURL.valueFrom" -}}
+{{- if .Values.langfuse.postgresql.directURL.valueFrom }}
+{{- toYaml .Values.langfuse.postgresql.directURL.valueFrom }}
+{{- else -}}
+secretKeyRef:
+  name: {{ include "langfuse.postgresqlSecretName" . }}
+  key: postgres-direct-url
+{{- end }}
+{{- end }}
+
+{{/*
+Create the valueFrom json for SHADOW_DATABASE_URL
+*/}}
+{{- define "langfuse.postgresql.shadowDatabaseURL.valueFrom" -}}
+{{- if .Values.langfuse.postgresql.shadowDatabaseURL.valueFrom }}
+{{- toYaml .Values.langfuse.postgresql.shadowDatabaseURL.valueFrom }}
+{{- else -}}
+secretKeyRef:
+  name: {{ include "langfuse.postgresqlSecretName" . }}
+  key: postgres-shadow-database-url
+{{- end }}
+{{- end }}
+
+{{/*
+Create the valueFrom json for NEXTAUTH_URL
+*/}}
+{{- define "langfuse.nextauth.url.valueFrom" -}}
+{{- if .Values.langfuse.nextauth.url.valueFrom }}
+{{- toYaml .Values.langfuse.nextauth.url.valueFrom }}
+{{- else -}}
+configMapRef:
+  name: {{ include "langfuse.nextauthConfigMapName" . }}
+  key: nextauth-url
+{{- end }}
+{{- end }}
+
+{{/*
+Create the valueFrom json for NEXTAUTH_SECRET
+*/}}
+{{- define "langfuse.nextauth.secret.valueFrom" -}}
+{{- if .Values.langfuse.nextauth.secret.valueFrom }}
+{{- toYaml .Values.langfuse.nextauth.secret.valueFrom }}
+{{- else -}}
+secretKeyRef:
+  name: {{ include "langfuse.nextauthSecretName" . }}
+  key: secret
 {{- end }}
 {{- end }}

--- a/charts/langfuse/templates/deployment.yaml
+++ b/charts/langfuse/templates/deployment.yaml
@@ -37,41 +37,29 @@ spec:
             - name: NODE_ENV
               value: {{ .Values.langfuse.nodeEnv | quote }}
             - name: DATABASE_USERNAME
-              value: {{ .Values.postgresql.auth.username | quote }}
+              valueFrom: {{ include "langfuse.postgresql.auth.username.valueFrom" . | nindent 16 }}
             - name: DATABASE_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "langfuse.postgresql.fullname" . }}
-                  key: postgres-password
+              valueFrom: {{ include "langfuse.postgresql.auth.password.valueFrom" . | nindent 16 }}
             - name: DATABASE_HOST
-              value: {{ .Values.postgresql.deploy | ternary (include "langfuse.postgresql.fullname" . | quote) (.Values.postgresql.host | quote) }}
+              valueFrom: {{ include "langfuse.postgresql.databaseHost.valueFrom" . | nindent 16 }}
             - name: DATABASE_NAME
-              value: {{ .Values.postgresql.auth.database | quote }}
+              valueFrom: {{ include "langfuse.postgresql.auth.database.valueFrom" . | nindent 16 }}
             {{- if not .Values.postgresql.deploy }}
             {{- if .Values.postgresql.directUrl }}
             - name: DIRECT_URL
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "langfuse.postgresqlSecretName" . }}
-                  key: postgres-direct-url
+              valueFrom: {{ include "langfuse.postgresql.directURL.valueFrom" . | nindent 16 }}
             {{- end }}
             {{- if .Values.postgresql.shadowDatabaseUrl }}
             - name: SHADOW_DATABASE_URL
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "langfuse.postgresqlSecretName" . }}
-                  key: postgres-shadow-database-url
+              valueFrom: {{ include "langfuse.postgresql.shadowDatabaseURL.valueFrom" . | nindent 16 }}
             {{- end }}
             {{- end }}
             - name: NEXTAUTH_URL
-              value: {{ .Values.langfuse.nextauth.url | quote }}
+              valueFrom: {{ include "langfuse.nextauth.url.valueFrom" . | nindent 16 }}
             - name: NEXTAUTH_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "langfuse.nextauthSecretName" . }}
-                  key: nextauth-secret
+              valueFrom: {{ include "langfuse.nextauth.secret.valueFrom" . | nindent 16 }}
             - name: SALT
-              value: {{ .Values.langfuse.salt | quote }}
+              valueFrom: {{ include "langfuse.salt.valueFrom" . | nindent 16 }}
             - name: TELEMETRY_ENABLED
               value: {{ .Values.langfuse.telemetryEnabled | quote }}
             - name: NEXT_PUBLIC_SIGN_UP_DISABLED

--- a/charts/langfuse/templates/nextauth-configmap.yaml
+++ b/charts/langfuse/templates/nextauth-configmap.yaml
@@ -1,0 +1,12 @@
+{{- if (not .Values.langfuse.nextauth.url.valueFrom) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "langfuse.nextauthConfigMapName" . }}
+  labels: 
+    {{- include "langfuse.labels" . | nindent 4 }}
+data:
+  {{- if not .Values.langfuse.nextauth.url.valueFrom }}
+  url: {{ .Values.langfuse.nextauth.url.value | toString | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/langfuse/templates/nextauth-secret.yaml
+++ b/charts/langfuse/templates/nextauth-secret.yaml
@@ -1,3 +1,4 @@
+{{- if (not .Values.langfuse.nextauth.secret.valueFrom) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -6,4 +7,7 @@ metadata:
     {{- include "langfuse.labels" . | nindent 4 }}
 type: Opaque
 data:
-  nextauth-secret: {{ .Values.langfuse.nextauth.secret | toString | b64enc }}
+  {{- if not .Values.langfuse.nextauth.secret.valueFrom }}
+  nextauth-secret: {{ .Values.langfuse.nextauth.secret.value | toString | b64enc }}
+  {{- end }}
+{{- end }}

--- a/charts/langfuse/templates/postgresql-configmap.yaml
+++ b/charts/langfuse/templates/postgresql-configmap.yaml
@@ -1,0 +1,22 @@
+{{- if (or (not .Values.langfuse.postgresql.auth.username.valueFrom) (not .Values.langfuse.postgresql.auth.database.valueFrom) (not .Values.langfuse.postgresql.host.valueFrom)) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "langfuse.postgresqlConfigMapName" . }}
+  labels: 
+    {{- include "langfuse.labels" . | nindent 4 }}
+data:
+  {{- if not .Values.langfuse.postgresql.auth.username.valueFrom }}
+  postgres-username: {{ .Values.langfuse.postgresql.auth.username.value | toString | quote }}
+  {{- end }}
+  {{- if not .Values.langfuse.postgresql.auth.database.valueFrom }}
+  postgres-database: {{ .Values.langfuse.postgresql.auth.database.value | toString | quote }}
+  {{- end }}
+  {{- if not .Values.langfuse.postgresql.host.valueFrom }}
+  {{- if .Values.langfuse.postgresql.host }}
+  postgres-database: {{ .Values.langfuse.postgresql.auth.database.value | toString | quote }}
+  {{- else }}
+  postgres-database: ""
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/langfuse/templates/postgresql-secret.yaml
+++ b/charts/langfuse/templates/postgresql-secret.yaml
@@ -14,4 +14,5 @@ data:
   {{- if .Values.postgresql.shadowDatabaseUrl }}
   postgres-shadow-database-url: {{ .Values.postgresql.shadowDatabaseUrl | toString | b64enc | quote }}
   {{- end }}
+  
 {{- end }}

--- a/charts/langfuse/templates/salt-secret.yaml
+++ b/charts/langfuse/templates/salt-secret.yaml
@@ -1,0 +1,13 @@
+{{- if (not .Values.langfuse.salt.valueFrom) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "langfuse.saltSecretName" . }}
+  labels:
+    {{- include "langfuse.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{- if not .Values.langfuse.salt.valueFrom }}
+  nextauth-secret: {{ .Values.langfuse.salt.value | toString | b64enc }}
+  {{- end }}
+{{- end }}

--- a/charts/langfuse/values.yaml
+++ b/charts/langfuse/values.yaml
@@ -12,12 +12,48 @@ fullnameOverride: ""
 langfuse:
   nodeEnv: production
   nextauth:
-    url: http://localhost:3000
-    secret: changeme
-  salt: changeme
+    url:
+      value: http://localhost:3000
+      valueFrom: {}
+    secret:
+      value: changeme
+      valueFrom: {}
+  salt:
+    value: changeme
+    valueFrom: {}
+  postgresql:
+    host:
+      value: ""
+      valueFrom: {}
+    auth:
+      username:
+        value: postgres
+        valueFrom:
+          configMapRef:
+            name: langfuse
+            key: postgres-username
+      password:
+        value: postgres
+        valueFrom:
+          secretRef:
+            name: langfuse
+            key: postgres-password
+      database:
+        value: postgres_langfuse
+        valueFrom:
+          configMapRef:
+            name: langfuse
+            key: postgres-database
+    directURL:
+      value: ""
+      valueFrom: {}
+    shadowDatabaseUrl:
+      value: ""
+      valueFrom: {}
   telemetryEnabled: True
   nextPublicSignUpDisabled: False
   enableExperimentalFeatures: False
+  additionalEnv: []
 
 serviceAccount:
   create: true


### PR DESCRIPTION
Close #7 

## What I changed
- Modified values.yaml to allow valueFrom to pull values from existing Secrets.
- Added a process in the helper to create a single ValueFrom JSON that consolidates existing values and Secrets created from the PostgreSQL helm, among others.
  - For details, please refer to the diagram below.

```mermaid
flowchart TD
    subgraph langfuse
        F["Deployment"]
        subgraph values
            subgraph postgresql
                subgraph auth
                    subgraph username
                        F(("ValueFrom(DATABASE_USERNAME)"))
                        G(("Value(DATABASE_USERNAME)"))
                    end
                    subgraph password
                        A(("ValueFrom(DATABASE_PASSWORD)"))
                        B(("Value(DATABASE_PASSWORD)"))
                    end
                end
                C["Secret"]
                H["ConfigMap"]
            end
        end
        subgraph helper
            J(("Value(DATABASE_USERNAME)"))
            E(("Value(DATABASE_PASSWORD)"))
        end
        I["Deployment"]
    end
    subgraph postgres
        D["Secret"]
    end

    A --> E
    B --> C
    C --> E
    D --> E
    G --> H
    H --> J
    F --> J

    E --> I
    J --> I
```