### PR TITLE
feat: support nested maps in langfuse.additionalEnv

### DIFF
--- a/charts/langfuse/templates/deployment.yaml
+++ b/charts/langfuse/templates/deployment.yaml
@@ -80,7 +80,11 @@ spec:
               value: {{ .Values.langfuse.enableExperimentalFeatures | quote }}
             {{- range $key, $value := .Values.langfuse.additionalEnv }}
             - name: {{ $key }}
+            {{- if kindIs "map" $value }}
+              {{- toYaml $value | nindent 14 }}
+            {{- else }}
               value: {{ $value | quote }}
+            {{- end }}
             {{- end }}
           ports:
             - name: http


### PR DESCRIPTION
**Summary**:  
This PR refactors the Helm `deployment.yaml` template to enhance the flexibility of defining additional environment variables. Specifically, it allows for nested maps in the `langfuse.additionalEnv` values, ensuring more complex environment configurations can be directly included without requiring additional processing.

**Changes**:  
- Modified the environment variable handling logic to support nested maps within `langfuse.additionalEnv`.
- Updated the template structure to process these nested maps correctly, ensuring that the resultant YAML reflects the intended configuration.

**Impact**:  
This change enables more complex environment setups and reduces the need for hardcoding or workarounds in the Helm templates. It is fully backward compatible, so existing deployments will not be affected unless the new feature is explicitly utilized.

**Testing**:  
- Tested with both flat and nested environment variable configurations to confirm that the YAML is generated correctly.
- Verified backward compatibility with existing configurations.