### PR TITLE
fix: pin major version 2 of langfuse/langfuse image

### DIFF
--- a/charts/langfuse/values.yaml
+++ b/charts/langfuse/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 image:
   repository: ghcr.io/langfuse/langfuse
   pullPolicy: Always
-  tag: ""
+  tag: "2"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/examples/langfuse-deployment.yaml
+++ b/examples/langfuse-deployment.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: langfuse
-          image: ghcr.io/langfuse/langfuse:latest
+          image: ghcr.io/langfuse/langfuse:2
           env:
             - name: NODE_ENV
               valueFrom:


### PR DESCRIPTION
With upcoming major versions, infrastructure requirements may change. To ensure that `pullPolicy: Always` does not accidentally install the next major version automatically, I have fixed the tag to the current major version(`2`) in this chart.