### PR TITLE
Update nextauth URL to avoid NEXTAUTH_URL invalid error

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The following table lists the useful configurable parameters of the Langfuse cha
 
 | Parameter | Description | Default |
 | --- | --- | --- |
-| `langfuse.nextauth.url` | When deploying to production, set the `nextauth.url` value to the canonical URL of your site. | `localhost:3000` |
+| `langfuse.nextauth.url` | When deploying to production, set the `nextauth.url` value to the canonical URL of your site. | `http://localhost:3000` |
 | `langfuse.nextauth.secret` | Used to encrypt the NextAuth.js JWT, and to hash email verification tokens. | `changeme` |
 | `langfuse.salt` | Salt for API key hashing | `changeme` |
 | `langfuse.telemetryEnabled` | Weither or not to enable telemetry (reports basic usage statistics of self-hosted instances to a centralized server). | `true` |

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The following table lists the useful configurable parameters of the Langfuse cha
 ```yaml
 langfuse:
   nextauth:
-    url: localhost:3000
+    url: http://localhost:3000
     secret: changeme
   salt: changeme
   telemetryEnabled: true
@@ -74,7 +74,7 @@ postgresql:
 ```yaml
 langfuse:
   nextauth:
-    url: localhost:3000
+    url: http://localhost:3000
     secret: changeme
   salt: changeme
   telemetryEnabled: true


### PR DESCRIPTION
Current documentation implies `langfuse.nextauth.url` to be a hostname without scheme. However, Langfuse `NEXTAUTH_URL` to require us to specify either `http://` or `https://`. Without HTTP scheme, user will encounter this when installing the helm chart:

> ❌ Invalid environment variables: { NEXTAUTH_URL: [ 'Invalid url' ] }

This PR updates relevant doc to make sure schemes are added in related documentation.