### PR TITLE
feat: set env from user managed secrets/configmaps

### DIFF
--- a/charts/langfuse/templates/deployment.yaml
+++ b/charts/langfuse/templates/deployment.yaml
@@ -93,9 +93,8 @@ spec:
               value: {{ .Values.langfuse.nextPublicSignUpDisabled | quote }}
             - name: ENABLE_EXPERIMENTAL_FEATURES
               value: {{ .Values.langfuse.enableExperimentalFeatures | quote }}
-            {{- range $key, $value := .Values.langfuse.additionalEnv }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
+            {{- if .Values.langfuse.additionalEnv }}
+              {{- toYaml .Values.langfuse.additionalEnv | nindent 12 }}
             {{- end }}
           ports:
             - name: http

--- a/charts/langfuse/values.yaml
+++ b/charts/langfuse/values.yaml
@@ -23,6 +23,20 @@ langfuse:
   extraVolumes: []
   extraInitContainers: []
   extraVolumeMounts: []
+  additionalEnv: []
+    # example
+    # - name: "DATABASE_PASSWORD"
+    #   valueFrom:
+    #     secretKeyRef:
+    #       name: "my-secrets"
+    #       key: "database-password"
+    # - name: "EMAIL_FROM_ADDRESS"
+    #   valueFrom:
+    #     configMapKeyRef:
+    #       name: "my-configmap"
+    #       key: "email-from-address"
+    # - name: DATABASE_USERNAME
+    #   value: langfuse-postgres  
 
 serviceAccount:
   create: true

--- a/examples/values-example.yaml
+++ b/examples/values-example.yaml
@@ -1,5 +1,7 @@
-# This values.yaml files assumes you have created your own secrets and configmap with necessary variables.
-# It's upto user to create secrets manually or via External Secrets Operator like https://external-secrets.io/latest or any other secret management tool.
+# This values.yaml file demonstrates how to use the `additonalEnvs` parameter with hard-coded values, configmaps, and secrets.
+# It assumes that you have created your own secrets and configmap with necessary variables.
+# Secrets must be set manually or via External Secrets Operator like https://external-secrets.io/latest or any other secret management tool.
+
 replicaCount: 1
 
 langfuse:

--- a/examples/values-example.yaml
+++ b/examples/values-example.yaml
@@ -1,0 +1,88 @@
+# This values.yaml files assumes you have created your own secrets and configmap with necessary variables.
+# It's upto user to create secrets manually or via External Secrets Operator like https://external-secrets.io/latest or any other secret management tool.
+replicaCount: 1
+
+langfuse:
+  port: 3000
+  nodeEnv: production
+  nextauth:
+    url: http://localhost:3000
+  telemetryEnabled: True
+  nextPublicSignUpDisabled: False
+  enableExperimentalFeatures: False
+  extraContainers: []
+  extraVolumes: []
+  extraInitContainers: []
+  extraVolumeMounts: []
+  additionalEnv:
+    - name: DATABASE_URL
+      valueFrom:
+        secretKeyRef:
+          name: my-secrets
+          key: langfuse-database-url
+    - name: DATABASE_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: my-secrets
+          key: langfuse-database-password
+    - name: DIRECT_URL
+      valueFrom:
+        secretKeyRef:
+          name: my-secrets
+          key: langfuse-direct-url
+    - name: SHADOW_DATABASE_URL
+      valueFrom:
+        secretKeyRef:
+          name: my-secrets
+          key: langfuse-shadow-database-url
+    - name: NEXTAUTH_SECRET
+      valueFrom:
+        secretKeyRef:
+          name: my-secrets
+          key: langfuse-nextauth-secret
+    - name: SALT
+      valueFrom:
+        secretKeyRef:
+          name: my-secrets
+          key: langfuse-salt
+    - name: SMTP_CONNECTION_URL
+      valueFrom:
+        secretKeyRef:
+          name: my-secrets
+          key: smtp-connection-url
+    - name: EMAIL_FROM_ADDRESS
+      valueFrom:
+        configMapKeyRef:
+          name: my-configmap
+          key: email-from-addres
+    - name: LANGFUSE_LOG_LEVEL
+      value: info
+    - name: LANGFUSE_LOG_FORMAT
+      value: json
+
+service:
+  type: ClusterIP
+  port: 3000
+
+ingress:
+  enabled: false
+
+resources: {}
+
+autoscaling:
+  enabled: false
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+postgresql:
+  deploy: false
+  auth:
+    username: langfuse
+    database: postgres_langfuse
+  host: localhost
+
+extraManifests: []


### PR DESCRIPTION
**Summary:**
This PR allows the user to have flexibility defining environment variables. via `langfuse.additionalEnv`. It ensures the env value can be assigned by any means for eg.

```yaml
env:
  - name: LANGFUSE_LOG_LEVEL
    value: info
  - name: DATABASE_PASSWORD
    valueFrom:
      secretKeyRef:
        key: langfuse-database-password
        name: my-secrets
  - name: EMAIL_FROM_ADDRESS
    valueFrom:
      configMapKeyRef:
        key: email-from-addres
        name: my-configmap
```

I have also added `examples/values-example.yaml` file for reference.

I know there are open PR, 
1. #14 : It has used `valueFrom`, but only for env variables mentioned in `values.yaml` file and it does not address other variables mentioned in [docs](https://langfuse.com/docs/deployment/self-host#configuring-environment-variables) like S3 keys/secrets, smtp connection url, etc.
2. #18 : It kind of solves but I think there is indentation issue