### PR TITLE
fix: Have readinessProbe call /api/public/ready

### DIFF
--- a/charts/langfuse/templates/deployment.yaml
+++ b/charts/langfuse/templates/deployment.yaml
@@ -102,7 +102,7 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /
+              path: /api/public/health
               port: http
           readinessProbe:
             httpGet:

--- a/charts/langfuse/templates/deployment.yaml
+++ b/charts/langfuse/templates/deployment.yaml
@@ -106,7 +106,7 @@ spec:
               port: http
           readinessProbe:
             httpGet:
-              path: /api/public/health
+              path: /api/public/ready
               port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}


### PR DESCRIPTION
# Why
- Readiness-endpoint has been introduced in the PRs mentioned below.
  - Implementation: https://github.com/langfuse/langfuse/pull/3222
  - Documentation update: https://github.com/langfuse/langfuse-docs/pull/788
- With this change, the health-endpoint no longer contains the `isSigtermReceived` check. This might result in the health-endpoint returning 200 OK, even when langfuse is being shut down. However, if there are multiple replicas, a terminating langfuse-pod should no longer receive any traffic. Therefore new `/api/public/ready`-endpoit should be used for `readinessProbe`
# What
- Have `readinessProbe` call new endpoint `/api/public/ready`

# Discussion points
- The current `livenessProbe` is pointing to `/` which asserts whether the UI can be served. The `livenessProbe` could also point to `/api/public/health`. However the health-endpoint also checks database dependencies. The livenessProbe shouldn't check database dependencies, as a failing livenessProbe can lead to a restarting container. langfuse is capable to recover from temporarily loosing database-connection. So there is no need to restart langfuse after loosing database connection. 
  - **TL;DR:** Current livenessProbe seems ok.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `readinessProbe` in `deployment.yaml` to use `/api/public/ready` endpoint.
> 
>   - **Behavior**:
>     - Update `readinessProbe` in `deployment.yaml` to call `/api/public/ready` instead of `/api/public/health`.
>   - **Discussion**:
>     - `livenessProbe` remains pointing to `/` to avoid unnecessary restarts due to database dependency checks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-k8s&utm_source=github&utm_medium=referral)<sup> for 24e6b688587c41acc52ac813b026c5be2eb18843. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->