### PR TITLE
Resolves https://github.com/langfuse/langfuse-k8s/issues/34: Custom s…

### DIFF
--- a/charts/langfuse/Chart.yaml
+++ b/charts/langfuse/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: langfuse
-version: 0.5.0
+version: 0.6.0
 description: Open source LLM engineering platform - LLM observability, metrics, evaluations, prompt management.
 type: application
 keywords:

--- a/charts/langfuse/templates/deployment.yaml
+++ b/charts/langfuse/templates/deployment.yaml
@@ -51,17 +51,25 @@ spec:
               value: "0.0.0.0"
             - name: PORT
               value: {{ .Values.langfuse.port | quote }}
+            {{- if .Values.postgresql.auth.username }}
             - name: DATABASE_USERNAME
               value: {{ .Values.postgresql.auth.username | quote }}
+            {{- end }}
+            {{- if .Values.postgresql.auth.password }}
             - name: DATABASE_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "langfuse.postgresql.fullname" . }}
                   key: postgres-password
+            {{- end }}
+            {{- if .Values.postgresql.host }}
             - name: DATABASE_HOST
               value: {{ .Values.postgresql.deploy | ternary (include "langfuse.postgresql.fullname" . | quote) (.Values.postgresql.host | quote) }}
+            {{- end }}
+            {{- if .Values.postgresql.database }}
             - name: DATABASE_NAME
               value: {{ .Values.postgresql.auth.database | quote }}
+            {{- end }}
             {{- if not .Values.postgresql.deploy }}
             {{- if .Values.postgresql.directUrl }}
             - name: DIRECT_URL
@@ -80,13 +88,17 @@ spec:
             {{- end }}
             - name: NEXTAUTH_URL
               value: {{ .Values.langfuse.nextauth.url | quote }}
+            {{- if .Values.langfuse.nextauth.secret }}
             - name: NEXTAUTH_SECRET
               valueFrom:
                 secretKeyRef:
                   name: {{ include "langfuse.nextauthSecretName" . }}
                   key: nextauth-secret
+            {{- end }}
+            {{- if .Values.langfuse.salt }}
             - name: SALT
               value: {{ .Values.langfuse.salt | quote }}
+            {{- end }}
             - name: TELEMETRY_ENABLED
               value: {{ .Values.langfuse.telemetryEnabled | quote }}
             - name: NEXT_PUBLIC_SIGN_UP_DISABLED

--- a/charts/langfuse/templates/nextauth-secret.yaml
+++ b/charts/langfuse/templates/nextauth-secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.langfuse.nextauth.secret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,3 +8,4 @@ metadata:
 type: Opaque
 data:
   nextauth-secret: {{ .Values.langfuse.nextauth.secret | toString | b64enc }}
+{{- end }}

--- a/charts/langfuse/templates/postgresql-secret.yaml
+++ b/charts/langfuse/templates/postgresql-secret.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.postgresql.deploy }}
+{{- if and (not .Values.postgresql.deploy)  (.Values.postgresql.auth.password) -}}
 apiVersion: v1
 kind: Secret
 metadata:


### PR DESCRIPTION
resolves https://github.com/langfuse/langfuse-k8s/issues/34


- allows to disable existing secrets and references
- update of readme with example
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Allows disabling of certain secrets in Langfuse Helm chart and updates templates to conditionally handle these secrets.
> 
>   - **Behavior**:
>     - Allows disabling of `langfuse.nextauth.secret` and `langfuse.salt` by setting them to `null` in `README.md`.
>     - Conditional creation of `nextauth-secret.yaml` and `postgresql-secret.yaml` based on secret values.
>   - **Templates**:
>     - Updates `deployment.yaml` to conditionally include environment variables for `DATABASE_USERNAME`, `DATABASE_PASSWORD`, `DATABASE_HOST`, `DATABASE_NAME`, `NEXTAUTH_SECRET`, and `SALT`.
>     - Modifies `nextauth-secret.yaml` and `postgresql-secret.yaml` to only create secrets if values are provided.
>   - **Misc**:
>     - Bumps chart version in `Chart.yaml` from `0.5.0` to `0.6.0`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-k8s&utm_source=github&utm_medium=referral)<sup> for 7482129b5689d2edac9851cba753358f35cd051f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->