### PR TITLE
feat: add option to set basepath for readiness/lineness

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The following table lists the useful configurable parameters of the Langfuse cha
 | --- | --- | --- |
 | `langfuse.nextauth.url` | When deploying to production, set the `nextauth.url` value to the canonical URL of your site. | `http://localhost:3000` |
 | `langfuse.nextauth.secret` | Used to encrypt the NextAuth.js JWT, and to hash email verification tokens. In case the value is set to `null`, then the default `NEXTAUTH_SECRET` environment variable will not be set. | `changeme` |
+| `langfuse.next.healthcheckBasePath` | Base path for the liveness/readiness probes. Should not include trailing slash. | `""` |
 | `langfuse.port` | Port to run Langfuse on | `3000` |
 | `langfuse.salt` | Salt for API key hashing. In case the value is set to `null`, then the default `SALT` environment variable will not be set. | `changeme` |
 | `langfuse.telemetryEnabled` | Weither or not to enable telemetry (reports basic usage statistics of self-hosted instances to a centralized server). | `true` |

--- a/charts/langfuse/Chart.yaml
+++ b/charts/langfuse/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: langfuse
-version: 0.7.0
+version: 0.8.0
 description: Open source LLM engineering platform - LLM observability, metrics, evaluations, prompt management.
 type: application
 keywords:

--- a/charts/langfuse/templates/deployment.yaml
+++ b/charts/langfuse/templates/deployment.yaml
@@ -114,11 +114,11 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /api/public/health
+              path: {{ .Values.langfuse.next.healthcheckBasePath | default "" | trimSuffix "/" }}/api/public/health
               port: http
           readinessProbe:
             httpGet:
-              path: /api/public/ready
+              path: {{ .Values.langfuse.next.healthcheckBasePath | default "" | trimSuffix "/" }}/api/public/ready
               port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/langfuse/values.yaml
+++ b/charts/langfuse/values.yaml
@@ -12,6 +12,8 @@ fullnameOverride: ""
 langfuse:
   port: 3000
   nodeEnv: production
+  next:
+    healthcheckBasePath: ""
   nextauth:
     url: http://localhost:3000
     secret: changeme

--- a/examples/values-example.yaml
+++ b/examples/values-example.yaml
@@ -7,6 +7,8 @@ replicaCount: 1
 langfuse:
   port: 3000
   nodeEnv: production
+  next:
+    healthcheckBasePath: ""
   nextauth:
     url: http://localhost:3000
   telemetryEnabled: True


### PR DESCRIPTION
Hello,

I'm deploying LangFuse at work, and we needed it to listen to a subpath.

So I built the Docker image with NEXT_PUBLIC_BASE_PATH set, but when I deploy, the readiness/liveness fail each time because the url is fixed to /api/public/{health,ready}.

I propose to add a .langfuse.next.healthcheckBasePath parameter that will be prepended to the paths.

TO DO before merge : 
- [x] restore readme
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds `healthcheckBasePath` option to configure base path for health checks in Langfuse Helm chart.
> 
>   - **Behavior**:
>     - Adds `langfuse.next.healthcheckBasePath` parameter in `values.yaml` to set a base path for liveness/readiness probes.
>     - Updates `deployment.yaml` to prepend `healthcheckBasePath` to `/api/public/health` and `/api/public/ready` paths.
>   - **Documentation**:
>     - Updates `README.md` to include `langfuse.next.healthcheckBasePath` in the configuration table.
>   - **Versioning**:
>     - Bumps chart version in `Chart.yaml` from `0.6.0` to `0.6.1`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-k8s&utm_source=github&utm_medium=referral)<sup> for 911dd8e4552f48d1074066a552664025fec223bc. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->