### PR TITLE
hotfix: service name for ingress

### DIFF
--- a/charts/langfuse/templates/ingress.yaml
+++ b/charts/langfuse/templates/ingress.yaml
@@ -49,11 +49,11 @@ spec:
             backend:
               {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
-                name: {{ $fullName }}
+                name: {{ $fullName }}-web
                 port:
                   number: {{ $svcPort }}
               {{- else }}
-              serviceName: {{ $fullName }}
+              serviceName: {{ $fullName }}-web
               servicePort: {{ $svcPort }}
               {{- end }}
           {{- end }}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix service name in `ingress.yaml` by appending '-web' for correct routing.
> 
>   - **Ingress Configuration**:
>     - Update service name from `{{ $fullName }}` to `{{ $fullName }}-web` in `ingress.yaml` for Kubernetes versions >=1.19 and <1.19.
>     - Ensures correct service routing by appending '-web' to the service name.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-k8s&utm_source=github&utm_medium=referral)<sup> for 3bfb557d7abd57815c62bfffce6ce1ca67a5609f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->