### PR TITLE
fix: use custom user-password instead of postgres password

### DIFF
--- a/charts/langfuse/Chart.yaml
+++ b/charts/langfuse/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: langfuse
-version: 0.8.0
+version: 0.9.0
 description: Open source LLM engineering platform - LLM observability, metrics, evaluations, prompt management.
 type: application
 keywords:

--- a/charts/langfuse/templates/deployment.yaml
+++ b/charts/langfuse/templates/deployment.yaml
@@ -60,7 +60,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "langfuse.postgresql.fullname" . }}
-                  key: postgres-password
+                  key: password
             {{- end }}
             {{- if .Values.postgresql.host }}
             - name: DATABASE_HOST


### PR DESCRIPTION
Fixes #41 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change database password key in `deployment.yaml` and update chart version to `0.9.0`.
> 
>   - **Behavior**:
>     - Change `key` from `postgres-password` to `password` in `deployment.yaml` for `DATABASE_PASSWORD` secret reference.
>   - **Versioning**:
>     - Update version in `Chart.yaml` from `0.8.0` to `0.9.0`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-k8s&utm_source=github&utm_medium=referral)<sup> for 2b63e4445862010f9d848f3a5a5893f3b63b9692. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->