### PR TITLE
Skip NEXTAUTH_SECRET and SALT in worker when source values are null

### DIFF
--- a/charts/langfuse/templates/deployment-worker.yaml
+++ b/charts/langfuse/templates/deployment-worker.yaml
@@ -84,13 +84,17 @@ spec:
             {{- end }}
             - name: NEXTAUTH_URL
               value: {{ .Values.langfuse.nextauth.url | quote }}
+            {{- if .Values.langfuse.nextauth.secret }}
             - name: NEXTAUTH_SECRET
               valueFrom:
                 secretKeyRef:
                   name: {{ include "langfuse.nextauthSecretName" . }}
                   key: nextauth-secret
+            {{- end }}
+            {{- if .Values.langfuse.salt }}
             - name: SALT
               value: {{ .Values.langfuse.salt | quote }}
+            {{- end }}
             - name: TELEMETRY_ENABLED
               value: {{ .Values.langfuse.telemetryEnabled | quote }}
             - name: NEXT_PUBLIC_SIGN_UP_DISABLED


### PR DESCRIPTION
Should fix issue when `NEXTAUTH_SECRET` env is set manually, but the worker still has a dependency on the non-existent `langfuse-nextauth` Secret resource.

Also updated `SALT` as well, since it looked inconsistent with the web Deployment. I don't think this is required, though.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add conditional checks for `NEXTAUTH_SECRET` and `SALT` in `deployment-worker.yaml` to avoid dependencies on non-existent secrets.
> 
>   - **Behavior**:
>     - Skip setting `NEXTAUTH_SECRET` in `deployment-worker.yaml` if `.Values.langfuse.nextauth.secret` is null.
>     - Skip setting `SALT` in `deployment-worker.yaml` if `.Values.langfuse.salt` is null.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-k8s&utm_source=github&utm_medium=referral)<sup> for 2b01c5ac60b8cfdb55373cb86c4daca1bb6c074e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->