### PR TITLE
feat: upgrade dependency versions + clickhouse sizing guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Replace `langfuse` in the values with your installation name in case you changed
 ```yaml
 # REDIS
 - name: "REDIS_CONNECTION_STRING"
-  value: "redis://default:changeme@langfuse-valkey-master:6379/0"
+  value: "redis://default:changeme@langfuse-valkey-primary:6379/0"
 # CLICKHOUSE
 - name: "CLICKHOUSE_MIGRATION_URL"
   value: "clickhouse://langfuse-clickhouse:9000"
@@ -61,6 +61,8 @@ helm upgrade langfuse langfuse/langfuse
 ### Configuration
 
 The following table lists the useful configurable parameters of the Langfuse chart and their default values.
+This chart sets low default resources for the ClickHouse cluster which may only work for small deployments.
+We recommend to update `clickhouse.resourcesPreset` to `2xlarge` for most deployments to account for ClickHouse's minimum sizing recommendations.
 
 | Parameter                                               | Description                                                                                                                                                                                                                                                                                                                                  | Default                         |
 |---------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------|

--- a/charts/langfuse/Chart.yaml
+++ b/charts/langfuse/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: langfuse
-version: 0.10.2
+version: 0.11.0
 description: Open source LLM engineering platform - LLM observability, metrics, evaluations, prompt management.
 type: application
 keywords:
@@ -15,15 +15,15 @@ sources:
   - https://github.com/langfuse/langfuse-k8s
 dependencies:
   - name: postgresql
-    version: 15.x.x
+    version: 16.x.x
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: postgresql.deploy
   - name: clickhouse
-    version: 6.x.x
+    version: 7.x.x
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: clickhouse.deploy
   - name: valkey
-    version: 1.x.x
+    version: 2.x.x
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: valkey.deploy
   - name: minio

--- a/charts/langfuse/values.yaml
+++ b/charts/langfuse/values.yaml
@@ -15,7 +15,7 @@ langfuse:
   next:
     healthcheckBasePath: ""
   nextauth:
-    url: http://localhost:3000
+    url: http://localhost:32100
     secret: changeme
   salt: changeme
   licenseKey: ""
@@ -59,7 +59,7 @@ langfuse:
   additionalEnv:
     # REDIS
     - name: "REDIS_CONNECTION_STRING"
-      value: "redis://default:changeme@langfuse-valkey-master:6379/0"
+      value: "redis://default:changeme@langfuse-valkey-primary:6379/0"
     # CLICKHOUSE
     - name: "CLICKHOUSE_MIGRATION_URL"
       value: "clickhouse://langfuse-clickhouse:9000"
@@ -97,9 +97,9 @@ podSecurityContext: {}
 securityContext: {}
 
 service:
-  type: ClusterIP
+  type: NodePort
   port: 3000
-  nodePort: ""
+  nodePort: "32100"
 
 ingress:
   enabled: false

--- a/charts/langfuse/values.yaml
+++ b/charts/langfuse/values.yaml
@@ -15,7 +15,7 @@ langfuse:
   next:
     healthcheckBasePath: ""
   nextauth:
-    url: http://localhost:32100
+    url: http://localhost:3000
     secret: changeme
   salt: changeme
   licenseKey: ""
@@ -97,9 +97,9 @@ podSecurityContext: {}
 securityContext: {}
 
 service:
-  type: NodePort
+  type: ClusterIP
   port: 3000
-  nodePort: "32100"
+  nodePort: ""
 
 ingress:
   enabled: false


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Upgrade dependency versions and update ClickHouse sizing guide in Helm chart.
> 
>   - **Dependencies**:
>     - Upgrade `postgresql` to `16.x.x`, `clickhouse` to `7.x.x`, and `valkey` to `2.x.x` in `Chart.yaml`.
>   - **Configuration**:
>     - Update `README.md` to recommend `clickhouse.resourcesPreset` to `2xlarge` for most deployments.
>   - **Misc**:
>     - Change `REDIS_CONNECTION_STRING` from `langfuse-valkey-master` to `langfuse-valkey-primary` in `README.md` and `values.yaml`.
>     - Bump chart `version` to `0.11.0` in `Chart.yaml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-k8s&utm_source=github&utm_medium=referral)<sup> for 534dc8b6fe0c804aef435662f8130cded056a1bb. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->