### PR TITLE
chore: added hostAliases overrides for langfuse web

### DIFF
--- a/charts/langfuse/templates/deployment-web.yaml
+++ b/charts/langfuse/templates/deployment-web.yaml
@@ -26,6 +26,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.langfuse.web.hostAliases }}
+      hostAliases:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "langfuse.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}


### PR DESCRIPTION
This is for the option to override hostAliases in the web pod of langfuse.
I was originated because of [this issue](https://github.com/langfuse/langfuse/issues/5119),
as a workaround to proxy requests for the custom oauth provider, and manipulate the response.
