### PR TITLE
Add support for envFrom

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ The following table lists the useful configurable parameters of the Langfuse cha
 | `langfuse.worker.vpa.minAllowed`                        | Minimum resource limits allowed by VPA for the worker component.                                                                                                                                                                                                                                                                             | `{}`                            |
 | `langfuse.worker.vpa.updatePolicy.updateMode`           | Update mode for VPA (e.g., `Auto`).                                                                                                                                                                                                                                                                                                          | `Auto`                          |
 | `langfuse.additionalEnv`                                | Dict that allow addition of additional env variables, see [documentation](https://langfuse.com/docs/deployment/self-host#configuring-environment-variables) for details.                                                                                                                                                                     | `{}`                            |
+| `langfuse.envFrom`                                      | Additional env variable from a config map or secret.                                                                                                                                                                                                                                                                                         | `[]`                            |
 | `service.type`                                          | Change the default k8s service type deployed with the application                                                                                                                                                                                                                                                                            | `ClusterIP`                     |
 | `service.port`                                          | Change the default k8s service port deployed with the application                                                                                                                                                                                                                                                                            | `3000`                          |
 | `service.nodePort`                                      | Specify the node port if type is `NodePort`.                                                                                                                                                                                                                                                                                                 |                                 |
@@ -220,7 +221,7 @@ postgresql:
 ```yaml
 langfuse:
   salt: null
-  nextauth: 
+  nextauth:
     secret: null
   extraVolumes:
     - name: db-keystore   # referencing an existing secret to mount server/client certs for postgres

--- a/charts/langfuse/templates/deployment-web.yaml
+++ b/charts/langfuse/templates/deployment-web.yaml
@@ -116,6 +116,10 @@ spec:
             {{- if .Values.langfuse.additionalEnv }}
               {{- toYaml .Values.langfuse.additionalEnv | nindent 12 }}
             {{- end }}
+          {{- if .Values.langfuse.envFrom }}
+          envFrom:
+              {{- toYaml .Values.langfuse.envFrom | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.langfuse.port }}

--- a/charts/langfuse/templates/deployment-worker.yaml
+++ b/charts/langfuse/templates/deployment-worker.yaml
@@ -104,6 +104,10 @@ spec:
             {{- if .Values.langfuse.additionalEnv }}
               {{- toYaml .Values.langfuse.additionalEnv | nindent 12 }}
             {{- end }}
+          {{- if .Values.langfuse.envFrom }}
+          envFrom:
+              {{- toYaml .Values.langfuse.envFrom | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.langfuse.port }}

--- a/charts/langfuse/values.yaml
+++ b/charts/langfuse/values.yaml
@@ -85,6 +85,8 @@ langfuse:
     - name: "LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE"
       value: "true"
 
+  envFrom: []
+
 serviceAccount:
   create: true
   annotations: {}


### PR DESCRIPTION
Hi,

I'd like to use `envFrom` to use k8s secrets to setup some of the environment variable, so here is a small PR to support it.
Let me know if I missed anything.

Thanks!

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds support for `envFrom` in Kubernetes deployments to source environment variables from config maps or secrets, with updates to `deployment-web.yaml`, `deployment-worker.yaml`, `values.yaml`, and `README.md`.
> 
>   - **Behavior**:
>     - Adds support for `envFrom` in `deployment-web.yaml` and `deployment-worker.yaml` to source environment variables from config maps or secrets.
>     - Updates `values.yaml` to include `envFrom` as an empty list by default.
>   - **Documentation**:
>     - Updates `README.md` to document the new `langfuse.envFrom` configuration option.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-k8s&utm_source=github&utm_medium=referral)<sup> for 001bec4bf15f0c3a57b9e7aaf73615c38579c280. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->