### PR TITLE
feat: added possibility to set pod labels

### DIFF
--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -1,5 +1,6 @@
 name: Release
 on:
+  workflow_dispatch:  # Allows manual triggering
   push:
     branches:
       - main

--- a/charts/langfuse/Chart.yaml
+++ b/charts/langfuse/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: langfuse
-version: 0.12.1
+version: 0.13.1
 description: Open source LLM engineering platform - LLM observability, metrics, evaluations, prompt management.
 type: application
 keywords:

--- a/charts/langfuse/templates/deployment-web.yaml
+++ b/charts/langfuse/templates/deployment-web.yaml
@@ -20,6 +20,16 @@ spec:
       {{- end }}
       labels:
         {{- include "langfuse.selectorLabels" . | nindent 8 }}
+        {{- if .Values.langfuse.commonPodLabels -}}
+        {{- range $key, $value := .Values.langfuse.commonPodLabels }}
+        {{ $key }}: {{ $value }}
+        {{- end }}
+        {{- end }}
+        {{- if .Values.langfuse.web.podLabels -}}
+        {{- range $key, $value := .Values.langfuse.web.podLabels }}
+        {{ $key }}: {{ $value }}
+        {{- end }}
+        {{- end }}
         app: web
     spec:
       {{- with .Values.imagePullSecrets }}

--- a/charts/langfuse/templates/deployment-worker.yaml
+++ b/charts/langfuse/templates/deployment-worker.yaml
@@ -20,6 +20,16 @@ spec:
       {{- end }}
       labels:
         {{- include "langfuse.selectorLabels" . | nindent 8 }}
+        {{- if .Values.langfuse.commonPodLabels -}}
+        {{- range $key, $value := .Values.langfuse.commonPodLabels }}
+        {{ $key }}: {{ $value }}
+        {{- end }}
+        {{- end }}
+        {{- if .Values.langfuse.worker.podLabels -}}
+        {{- range $key, $value := .Values.langfuse.worker.podLabels }}
+        {{ $key }}: {{ $value }}
+        {{- end }}
+        {{- end }}
         app: worker
     spec:
       {{- with .Values.imagePullSecrets }}

--- a/charts/langfuse/values.yaml
+++ b/charts/langfuse/values.yaml
@@ -26,8 +26,12 @@ langfuse:
   extraVolumes: []
   extraInitContainers: []
   extraVolumeMounts: []
+  commonPodLabels:
+    # my-custom-label-key: my-custom-label-value
 
   web:
+    podLabels:
+      # my-custom-web-label-key: my-custom-web-label-value
     resources: {}
     hpa:
       enabled: false
@@ -42,6 +46,8 @@ langfuse:
       updatePolicy:
         updateMode: Auto
   worker:
+    podLabels:
+      # my-custom-worker-label-key: my-custom-worker-label-value
     resources: {}
     hpa:
       enabled: false


### PR DESCRIPTION
This PR gives the possibility to set common pod labels and service specific custom pod labels
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds support for setting common and service-specific pod labels in Langfuse Helm chart deployments.
> 
>   - **Behavior**:
>     - Adds support for setting common pod labels via `langfuse.commonPodLabels` in `deployment-web.yaml` and `deployment-worker.yaml`.
>     - Adds support for setting service-specific pod labels via `langfuse.web.podLabels` and `langfuse.worker.podLabels` in `deployment-web.yaml` and `deployment-worker.yaml`.
>   - **Configuration**:
>     - Updates `values.yaml` to include `commonPodLabels`, `web.podLabels`, and `worker.podLabels` sections for user-defined labels.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-k8s&utm_source=github&utm_medium=referral)<sup> for af6b72108275271f29fc8eebf10d5c2fdca67b5d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->