### PR TITLE
feat: added possibility to set extra pod labels

### DIFF
--- a/charts/langfuse/templates/web/deployment.yaml
+++ b/charts/langfuse/templates/web/deployment.yaml
@@ -24,6 +24,16 @@ spec:
       {{- end }}
       labels:
         {{- include "langfuse.selectorLabels" . | nindent 8 }}
+        {{- if .Values.langfuse.podLabels -}}
+        {{- range $key, $value := .Values.langfuse.podLabels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+        {{- end }}
+        {{- if .Values.langfuse.web.podLabels -}}
+        {{- range $key, $value := .Values.langfuse.web.podLabels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+        {{- end }}
         app: web
     spec:
       {{- with (.Values.langfuse.web.image.pullSecrets | default .Values.langfuse.image.pullSecrets) }}

--- a/charts/langfuse/templates/worker/deployment.yaml
+++ b/charts/langfuse/templates/worker/deployment.yaml
@@ -20,6 +20,16 @@ spec:
       {{- end }}
       labels:
         {{- include "langfuse.selectorLabels" . | nindent 8 }}
+        {{- if .Values.langfuse.podLabels -}}
+        {{- range $key, $value := .Values.langfuse.podLabels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+        {{- end }}
+        {{- if .Values.langfuse.worker.podLabels -}}
+        {{- range $key, $value := .Values.langfuse.worker.podLabels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+        {{- end }}
         app: worker
     spec:
       {{- with (.Values.langfuse.worker.image.pullSecrets | default .Values.langfuse.image.pullSecrets) }}

--- a/charts/langfuse/values.yaml
+++ b/charts/langfuse/values.yaml
@@ -115,6 +115,9 @@ langfuse:
   extraInitContainers: []
   # -- Allows additional volume mounts to be added to all langfuse deployments
   extraVolumeMounts: []
+  # -- pod labels for the langfuse deployments
+  podLabels:
+    # myCustomLabelKey: myCustomLabelValue
 
   # Web deployment configuration
   web:
@@ -139,6 +142,10 @@ langfuse:
       additionalLabels: {}
       # -- Annotations for the langfuse web application service
       annotations: {}
+
+    # -- labels for the langfuse web pods.
+    podLabels:
+    # myCustomLabelKey: myCustomLabelValue
 
     # -- Resources for the langfuse web pods. Defaults to the global resources
     resources: {}
@@ -213,6 +220,10 @@ langfuse:
       pullPolicy: Null
       # -- The pull secrets to use for the langfuse worker pods. Using `langfuse.image.pullSecrets` if not set.
       pullSecrets: Null
+
+    # -- labels for the langfuse worker pods.
+    podLabels:
+    # myCustomLabelKey: myCustomLabelValue
 
     # -- Resources for the langfuse worker pods. Defaults to the global resources
     resources: {}


### PR DESCRIPTION
This PR gives the possibility to set common pod labels and service specific custom pod labels


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds support for setting common and service-specific pod labels in Helm chart deployments for web and worker services.
> 
>   - **Behavior**:
>     - Adds support for setting `commonPodLabels` and service-specific `podLabels` in `deployment-web.yaml` and `deployment-worker.yaml`.
>     - Labels are conditionally applied based on `.Values.langfuse.commonPodLabels` and `.Values.langfuse.[web|worker].podLabels`.
>   - **Configuration**:
>     - Introduces `commonPodLabels` under `langfuse` in `values.yaml` for shared labels.
>     - Adds `podLabels` under `langfuse.web` and `langfuse.worker` in `values.yaml` for service-specific labels.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-k8s&utm_source=github&utm_medium=referral)<sup> for f6d636b68ecef6aa87453c36a14888bc60cbb443. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->