### PR TITLE
fix: parse service annotations to valid yaml

### DIFF
--- a/charts/langfuse/Chart.yaml
+++ b/charts/langfuse/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: langfuse
-version: 0.12.1
+version: 0.12.2
 description: Open source LLM engineering platform - LLM observability, metrics, evaluations, prompt management.
 type: application
 keywords:

--- a/charts/langfuse/templates/service.yaml
+++ b/charts/langfuse/templates/service.yaml
@@ -7,10 +7,12 @@ metadata:
     {{- with .Values.service.additionalLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-{{- if .Values.service.annotations }}
+  {{- if .Values.service.annotations }}
   annotations:
-  {{ toYaml .Values.service.annotations | indent 4 }}
-{{- end }}
+    {{- with .Values.service.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes YAML parsing of service annotations in `service.yaml` and bumps version to `0.12.2`.
> 
>   - **Behavior**:
>     - Fixes parsing of service annotations in `service.yaml` by wrapping with `with` and using `nindent` for proper YAML formatting.
>   - **Versioning**:
>     - Bumps version in `Chart.yaml` from `0.12.1` to `0.12.2`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-k8s&utm_source=github&utm_medium=referral)<sup> for d8935f5fd2c0a0bad1c20dfe6506ec1cd723cfca. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->