### PR TITLE
enable TLS for Redis

### DIFF
--- a/charts/langfuse/README.md
+++ b/charts/langfuse/README.md
@@ -163,9 +163,9 @@ Open source LLM engineering platform - LLM observability, metrics, evaluations, 
 | redis.host | string | `""` | Redis host to connect to. If redis.deploy is true, this will be set automatically based on the release name. |
 | redis.port | int | `6379` | Redis port to connect to. |
 | redis.primary.extraFlags | list | `["--maxmemory-policy noeviction"]` | Extra flags for the valkey deployment. Must include `--maxmemory-policy noeviction`. |
-| redis.tls.enabled | bool | `false` | Set to `true` to enable TLS/SSL encrypted connection to the Redis server |
 | redis.tls.caPath | string | `""` | Path to the CA certificate file for TLS verification |
 | redis.tls.certPath | string | `""` | Path to the client certificate file for mutual TLS authentication |
+| redis.tls.enabled | bool | `false` | Set to `true` to enable TLS/SSL encrypted connection to the Redis server |
 | redis.tls.keyPath | string | `""` | Path to the client private key file for mutual TLS authentication |
 | s3.accessKeyId | object | `{"secretKeyRef":{"key":"","name":""},"value":""}` | S3 accessKeyId to use for all uploads. Can be overridden per upload type. |
 | s3.auth.existingSecret | string | `""` | If you want to use an existing secret for the root user password, set the name of the secret here. (`s3.auth.rootUser` and `s3.auth.rootPassword` will be ignored and picked up from this secret). |

--- a/charts/langfuse/README.md
+++ b/charts/langfuse/README.md
@@ -163,10 +163,10 @@ Open source LLM engineering platform - LLM observability, metrics, evaluations, 
 | redis.host | string | `""` | Redis host to connect to. If redis.deploy is true, this will be set automatically based on the release name. |
 | redis.port | int | `6379` | Redis port to connect to. |
 | redis.primary.extraFlags | list | `["--maxmemory-policy noeviction"]` | Extra flags for the valkey deployment. Must include `--maxmemory-policy noeviction`. |
-| redis.tls.enabled | bool | `false` | Set to `true` to enable TLS/SSL encrypted connection to the Redis server. When enabled, automatically uses `rediss://` protocol. |
-| redis.tls.caPath | string | `""` | Path to the CA certificate file for TLS verification. Sets environment variable `REDIS_TLS_CA_PATH`. |
-| redis.tls.certPath | string | `""` | Path to the client certificate file for mutual TLS authentication. Sets environment variable `REDIS_TLS_CERT_PATH`. |
-| redis.tls.keyPath | string | `""` | Path to the client private key file for mutual TLS authentication. Sets environment variable `REDIS_TLS_KEY_PATH`. |
+| redis.tls.enabled | bool | `false` | Set to `true` to enable TLS/SSL encrypted connection to the Redis server |
+| redis.tls.caPath | string | `""` | Path to the CA certificate file for TLS verification |
+| redis.tls.certPath | string | `""` | Path to the client certificate file for mutual TLS authentication |
+| redis.tls.keyPath | string | `""` | Path to the client private key file for mutual TLS authentication |
 | s3.accessKeyId | object | `{"secretKeyRef":{"key":"","name":""},"value":""}` | S3 accessKeyId to use for all uploads. Can be overridden per upload type. |
 | s3.auth.existingSecret | string | `""` | If you want to use an existing secret for the root user password, set the name of the secret here. (`s3.auth.rootUser` and `s3.auth.rootPassword` will be ignored and picked up from this secret). |
 | s3.auth.rootPassword | string | `""` | Password for MinIO root user |

--- a/charts/langfuse/README.md
+++ b/charts/langfuse/README.md
@@ -163,6 +163,10 @@ Open source LLM engineering platform - LLM observability, metrics, evaluations, 
 | redis.host | string | `""` | Redis host to connect to. If redis.deploy is true, this will be set automatically based on the release name. |
 | redis.port | int | `6379` | Redis port to connect to. |
 | redis.primary.extraFlags | list | `["--maxmemory-policy noeviction"]` | Extra flags for the valkey deployment. Must include `--maxmemory-policy noeviction`. |
+| redis.tls.enabled | bool | `false` | Set to `true` to enable TLS/SSL encrypted connection to the Redis server. When enabled, automatically uses `rediss://` protocol. |
+| redis.tls.caPath | string | `""` | Path to the CA certificate file for TLS verification. Sets environment variable `REDIS_TLS_CA_PATH`. |
+| redis.tls.certPath | string | `""` | Path to the client certificate file for mutual TLS authentication. Sets environment variable `REDIS_TLS_CERT_PATH`. |
+| redis.tls.keyPath | string | `""` | Path to the client private key file for mutual TLS authentication. Sets environment variable `REDIS_TLS_KEY_PATH`. |
 | s3.accessKeyId | object | `{"secretKeyRef":{"key":"","name":""},"value":""}` | S3 accessKeyId to use for all uploads. Can be overridden per upload type. |
 | s3.auth.existingSecret | string | `""` | If you want to use an existing secret for the root user password, set the name of the secret here. (`s3.auth.rootUser` and `s3.auth.rootPassword` will be ignored and picked up from this secret). |
 | s3.auth.rootPassword | string | `""` | Password for MinIO root user |

--- a/charts/langfuse/templates/_helpers.tpl
+++ b/charts/langfuse/templates/_helpers.tpl
@@ -259,6 +259,20 @@ Get value of a specific environment variable from additionalEnv if it exists
   value: {{ .Values.redis.tls.enabled | quote }}
 - name: REDIS_CONNECTION_STRING
   value: "{{ if .Values.redis.tls.enabled }}rediss{{ else }}redis{{ end }}://{{ .Values.redis.auth.username | default "default" }}:$(REDIS_PASSWORD)@{{ include "langfuse.redis.hostname" . }}:{{ .Values.redis.port }}/{{ .Values.redis.auth.database }}"
+{{- if .Values.redis.tls.enabled }}
+{{- if .Values.redis.tls.caPath }}
+- name: REDIS_TLS_CA_PATH
+  value: {{ .Values.redis.tls.caPath | quote }}
+{{- end }}
+{{- if .Values.redis.tls.certPath }}
+- name: REDIS_TLS_CERT_PATH
+  value: {{ .Values.redis.tls.certPath | quote }}
+{{- end }}
+{{- if .Values.redis.tls.keyPath }}
+- name: REDIS_TLS_KEY_PATH
+  value: {{ .Values.redis.tls.keyPath | quote }}
+{{- end }}
+{{- end }}
 {{- end -}}
 
 

--- a/charts/langfuse/templates/_helpers.tpl
+++ b/charts/langfuse/templates/_helpers.tpl
@@ -255,6 +255,8 @@ Get value of a specific environment variable from additionalEnv if it exists
 {{- else }}
   value: {{ required "Using an existing secret or redis.auth.password is required" .Values.redis.auth.password | quote }}
 {{- end }}
+- name: REDIS_TLS_ENABLED
+  value: {{ .Values.redis.tls.enabled | quote }}
 - name: REDIS_CONNECTION_STRING
   value: "redis://{{ .Values.redis.auth.username | default "default" }}:$(REDIS_PASSWORD)@{{ include "langfuse.redis.hostname" . }}:{{ .Values.redis.port }}/{{ .Values.redis.auth.database }}"
 {{- end -}}

--- a/charts/langfuse/templates/_helpers.tpl
+++ b/charts/langfuse/templates/_helpers.tpl
@@ -258,7 +258,7 @@ Get value of a specific environment variable from additionalEnv if it exists
 - name: REDIS_TLS_ENABLED
   value: {{ .Values.redis.tls.enabled | quote }}
 - name: REDIS_CONNECTION_STRING
-  value: "redis://{{ .Values.redis.auth.username | default "default" }}:$(REDIS_PASSWORD)@{{ include "langfuse.redis.hostname" . }}:{{ .Values.redis.port }}/{{ .Values.redis.auth.database }}"
+  value: "{{ if .Values.redis.tls.enabled }}rediss{{ else }}redis{{ end }}://{{ .Values.redis.auth.username | default "default" }}:$(REDIS_PASSWORD)@{{ include "langfuse.redis.hostname" . }}:{{ .Values.redis.port }}/{{ .Values.redis.auth.database }}"
 {{- end -}}
 
 

--- a/charts/langfuse/values.yaml
+++ b/charts/langfuse/values.yaml
@@ -324,7 +324,7 @@ redis:
   # -- Redis port to connect to.
   port: 6379
   
-  # TLS configuration
+  # Redis TLS configuration
   tls:
     # -- Set to `true` to enable TLS/SSL encrypted connection to the Redis server
     enabled: false

--- a/charts/langfuse/values.yaml
+++ b/charts/langfuse/values.yaml
@@ -328,6 +328,12 @@ redis:
   tls:
     # -- Set to `true` to enable TLS/SSL encrypted connection to the Redis server
     enabled: false
+    # -- Path to the CA certificate file for TLS verification
+    caPath: ""
+    # -- Path to the client certificate file for mutual TLS authentication
+    certPath: ""
+    # -- Path to the client private key file for mutual TLS authentication
+    keyPath: ""
   
   # Authentication configuration
   auth:

--- a/charts/langfuse/values.yaml
+++ b/charts/langfuse/values.yaml
@@ -324,6 +324,11 @@ redis:
   # -- Redis port to connect to.
   port: 6379
   
+  # TLS configuration
+  tls:
+    # -- Set to `true` to enable TLS/SSL encrypted connection to the Redis server
+    enabled: false
+  
   # Authentication configuration
   auth:
     # -- Configure the password by value or existing secret reference


### PR DESCRIPTION
# Redis TLS Support

## Features
- Added TLS support for Redis using REDIS_CONNECTION_STRING
- When TLS is enabled, the connection string automatically uses the `rediss://` protocol
- Implemented support for custom TLS certificates through the following configuration options:
  - `.Values.redis.tls.caPath`: CA certificate path (sets `REDIS_TLS_CA_PATH`)
  - `.Values.redis.tls.certPath`: Client certificate path (sets `REDIS_TLS_CERT_PATH`) 
  - `.Values.redis.tls.keyPath`: Client key path (sets `REDIS_TLS_KEY_PATH`)

These changes enable secure Redis connections in environments that require TLS encryption.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add TLS support for Redis with custom certificate configuration in Helm chart.
> 
>   - **TLS Support for Redis**:
>     - Added TLS support using `REDIS_CONNECTION_STRING` in `_helpers.tpl`.
>     - Uses `rediss://` protocol when TLS is enabled.
>     - Supports custom TLS certificates with `redis.tls.caPath`, `redis.tls.certPath`, and `redis.tls.keyPath` in `values.yaml`.
>   - **Configuration Changes**:
>     - Updated `values.yaml` to include TLS options under `redis.tls`.
>     - Modified `README.md` to document new TLS configuration options.
>   - **Environment Variables**:
>     - Added `REDIS_TLS_ENABLED`, `REDIS_TLS_CA_PATH`, `REDIS_TLS_CERT_PATH`, and `REDIS_TLS_KEY_PATH` in `_helpers.tpl` for environment variable configuration.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-k8s&utm_source=github&utm_medium=referral)<sup> for 7f2b5f15d23b1c8ff5c6b9fd90d7eeabb9e7cc60. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->