### PR TITLE
feat: add annotation support

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -23,7 +23,8 @@ This guide outlines the changes needed when upgrading from Langfuse Helm Chart v
       # New
       langfuse:
         serviceAccount: [...]
-        podAnnotations: {}
+        pod:
+          annotations: {}
         podSecurityContext: {}
         securityContext: {}
         resources: {}

--- a/charts/langfuse/Chart.yaml
+++ b/charts/langfuse/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: langfuse
-version: 1.0.0-rc.4
+version: 1.0.0-rc.5
 description: Open source LLM engineering platform - LLM observability, metrics, evaluations, prompt management.
 type: application
 keywords:

--- a/charts/langfuse/README.md
+++ b/charts/langfuse/README.md
@@ -50,6 +50,7 @@ Open source LLM engineering platform - LLM observability, metrics, evaluations, 
 | fullnameOverride | string | `""` | Override the full name of the deployed resources, defaults to a combination of the release name and the name for the selector labels |
 | langfuse.additionalEnv | list | `[]` | List of additional environment variables to be added to all langfuse deployments. See [documentation](https://langfuse.com/docs/deployment/self-host#configuring-environment-variables) for details. |
 | langfuse.affinity | object | `{}` | Affinity for all langfuse deployments |
+| langfuse.deployment.annotations | object | `{}` | Annotations for all langfuse deployments |
 | langfuse.encryptionKey | object | `{"secretKeyRef":{"key":"","name":""},"value":""}` | Used to encrypt sensitive data. Must be 256 bits (64 string characters in hex format). Generate via `openssl rand -hex 32`. |
 | langfuse.extraContainers | list | `[]` | Allows additional containers to be added to all langfuse deployments |
 | langfuse.extraInitContainers | list | `[]` | Allows additional init containers to be added to all langfuse deployments |
@@ -75,7 +76,7 @@ Open source LLM engineering platform - LLM observability, metrics, evaluations, 
 | langfuse.nextauth.url | string | `"http://localhost:3000"` | When deploying to production, set the `nextauth.url` value to the canonical URL of your site. |
 | langfuse.nodeEnv | string | `"production"` | Node.js environment to use for all langfuse deployments |
 | langfuse.nodeSelector | object | `{}` | Node selector for all langfuse deployments |
-| langfuse.podAnnotations | object | `{}` | Pod annotations for all langfuse deployments |
+| langfuse.pod.annotations | object | `{}` | Annotations for all langfuse pods |
 | langfuse.podSecurityContext | object | `{}` | Pod security context for all langfuse deployments |
 | langfuse.replicas | int | `1` | Number of replicas to use for all langfuse deployments. Can be overridden by the individual deployments |
 | langfuse.resources | object | `{}` | Resources for all langfuse deployments. Can be overridden by the individual deployments |
@@ -85,6 +86,7 @@ Open source LLM engineering platform - LLM observability, metrics, evaluations, 
 | langfuse.serviceAccount.create | bool | `true` | Whether to create a service account for all langfuse deployments |
 | langfuse.serviceAccount.name | string | `""` | Override the name of the service account to use, discovered automatically if not set |
 | langfuse.tolerations | list | `[]` | Tolerations for all langfuse deployments |
+| langfuse.web.deployment.annotations | object | `{}` | Annotations for the web deployment |
 | langfuse.web.hostAliases | list | `[]` | Adding records to /etc/hosts in the pod's network. |
 | langfuse.web.hpa.enabled | bool | `false` | Set to `true` to enable HPA for the langfuse web pods |
 | langfuse.web.hpa.maxReplicas | int | `2` | The maximum number of replicas to use for the langfuse web pods |
@@ -100,6 +102,7 @@ Open source LLM engineering platform - LLM observability, metrics, evaluations, 
 | langfuse.web.livenessProbe.periodSeconds | int | `10` | Period seconds for livenessProbe. |
 | langfuse.web.livenessProbe.successThreshold | int | `1` | Success threshold for livenessProbe. |
 | langfuse.web.livenessProbe.timeoutSeconds | int | `5` | Timeout seconds for livenessProbe. |
+| langfuse.web.pod.annotations | object | `{}` | Annotations for the web pods |
 | langfuse.web.readinessProbe.failureThreshold | int | `3` | Failure threshold for readinessProbe. |
 | langfuse.web.readinessProbe.initialDelaySeconds | int | `20` | Initial delay seconds for readinessProbe. |
 | langfuse.web.readinessProbe.path | string | `"/api/public/ready"` | Path to check for readiness. |
@@ -118,6 +121,7 @@ Open source LLM engineering platform - LLM observability, metrics, evaluations, 
 | langfuse.web.vpa.maxAllowed | object | `{}` | The maximum allowed resources for the langfuse web pods |
 | langfuse.web.vpa.minAllowed | object | `{}` | The minimum allowed resources for the langfuse web pods |
 | langfuse.web.vpa.updatePolicy.updateMode | string | `"Auto"` | The update policy mode for the langfuse web pods |
+| langfuse.worker.deployment.annotations | object | `{}` | Annotations for the worker deployment |
 | langfuse.worker.hpa.enabled | bool | `false` | Set to `true` to enable HPA for the langfuse worker pods |
 | langfuse.worker.hpa.maxReplicas | int | `2` | The maximum number of replicas to use for the langfuse worker pods |
 | langfuse.worker.hpa.minReplicas | int | `1` | The minimum number of replicas to use for the langfuse worker pods |
@@ -131,6 +135,7 @@ Open source LLM engineering platform - LLM observability, metrics, evaluations, 
 | langfuse.worker.livenessProbe.periodSeconds | int | `10` | Period seconds for livenessProbe. |
 | langfuse.worker.livenessProbe.successThreshold | int | `1` | Success threshold for livenessProbe. |
 | langfuse.worker.livenessProbe.timeoutSeconds | int | `5` | Timeout seconds for livenessProbe. |
+| langfuse.worker.pod.annotations | object | `{}` | Annotations for the worker pods |
 | langfuse.worker.replicas | string | `nil` | Number of replicas to use if HPA is not enabled. Defaults to the global replicas |
 | langfuse.worker.resources | object | `{}` | Resources for the langfuse worker pods. Defaults to the global resources |
 | langfuse.worker.vpa.controlledResources | list | `[]` | The resources to control for the langfuse worker pods |

--- a/charts/langfuse/README.md
+++ b/charts/langfuse/README.md
@@ -1,6 +1,6 @@
 # langfuse
 
-![Version: 1.0.0-rc.4](https://img.shields.io/badge/Version-1.0.0--rc.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.29.1](https://img.shields.io/badge/AppVersion-3.29.1-informational?style=flat-square)
+![Version: 1.0.0-rc.5](https://img.shields.io/badge/Version-1.0.0--rc.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.29.1](https://img.shields.io/badge/AppVersion-3.29.1-informational?style=flat-square)
 
 Open source LLM engineering platform - LLM observability, metrics, evaluations, prompt management.
 

--- a/charts/langfuse/templates/web/deployment.yaml
+++ b/charts/langfuse/templates/web/deployment.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "langfuse.fullname" . }}-web
   labels:
     {{- include "langfuse.labels" . | nindent 4 }}
+  {{- with (coalesce .Values.langfuse.web.deployment.annotations .Values.langfuse.deployment.annotations) }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.langfuse.web.hpa.enabled }}
   replicas: {{ .Values.langfuse.web.replicas | default .Values.langfuse.replicas }}
@@ -18,7 +22,8 @@ spec:
       app: web
   template:
     metadata:
-      {{- with .Values.langfuse.podAnnotations }}
+      {{- $podAnnotations := merge (.Values.langfuse.web.pod.annotations | default dict) (.Values.langfuse.pod.annotations | default dict) }}
+      {{- with $podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/langfuse/templates/worker/deployment.yaml
+++ b/charts/langfuse/templates/worker/deployment.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "langfuse.fullname" . }}-worker
   labels:
     {{- include "langfuse.labels" . | nindent 4 }}
+  {{- with (coalesce .Values.langfuse.worker.deployment.annotations .Values.langfuse.deployment.annotations) }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.langfuse.worker.hpa.enabled }}
   replicas: {{ .Values.langfuse.worker.replicas | default .Values.langfuse.replicas }}
@@ -14,7 +18,8 @@ spec:
       app: worker
   template:
     metadata:
-      {{- with .Values.langfuse.podAnnotations }}
+      {{- $podAnnotations := merge (.Values.langfuse.worker.pod.annotations | default dict) (.Values.langfuse.pod.annotations | default dict) }}
+      {{- with $podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -51,6 +56,10 @@ spec:
             {{- if .Values.langfuse.additionalEnv }}
               {{- toYaml .Values.langfuse.additionalEnv | nindent 12 }}
             {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.langfuse.worker.port | default 3000 }}
+              protocol: TCP
           livenessProbe:
             httpGet:
               path: /api/health

--- a/charts/langfuse/values.yaml
+++ b/charts/langfuse/values.yaml
@@ -79,8 +79,6 @@ langfuse:
       # -- The name of the secret to use for TLS Key
       secretName: ""
 
-  # -- Pod annotations for all langfuse deployments
-  podAnnotations: {}
   # -- Pod security context for all langfuse deployments
   podSecurityContext: {}
   # -- Security context for all langfuse deployments
@@ -91,8 +89,12 @@ langfuse:
   tolerations: []
   # -- Affinity for all langfuse deployments
   affinity: {}
-
-
+  pod:
+    # -- Annotations for all langfuse pods
+    annotations: {}
+  deployment:
+    # -- Annotations for all langfuse deployments
+    annotations: {}
   # -- Number of replicas to use for all langfuse deployments. Can be overridden by the individual deployments
   replicas: 1
   # -- Resources for all langfuse deployments. Can be overridden by the individual deployments
@@ -127,7 +129,12 @@ langfuse:
       pullPolicy: Null
       # -- The pull secrets to use for the langfuse web pods. Using `langfuse.image.pullSecrets` if not set.
       pullSecrets: Null
-
+    deployment:
+      # -- Annotations for the web deployment
+      annotations: {}
+    pod:
+      # -- Annotations for the web pods
+      annotations: {}
     service:
       # -- The type of service to use for the langfuse web application
       type: ClusterIP
@@ -213,6 +220,12 @@ langfuse:
       pullPolicy: Null
       # -- The pull secrets to use for the langfuse worker pods. Using `langfuse.image.pullSecrets` if not set.
       pullSecrets: Null
+    deployment:
+      # -- Annotations for the worker deployment
+      annotations: {}
+    pod:
+      # -- Annotations for the worker pods
+      annotations: {}
 
     # -- Resources for the langfuse worker pods. Defaults to the global resources
     resources: {}


### PR DESCRIPTION
Fixes https://github.com/langfuse/langfuse-k8s/issues/38
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds annotation support for Langfuse Helm charts, updating version to 1.0.0-rc.5 and documentation accordingly.
> 
>   - **Annotation Support**:
>     - Adds support for annotations in `web/deployment.yaml` and `worker/deployment.yaml` for both deployments and pods.
>     - Introduces `langfuse.deployment.annotations` and `langfuse.pod.annotations` in `values.yaml`.
>     - Adds specific annotations for `web` and `worker` components in `values.yaml`.
>   - **Version Update**:
>     - Updates version to `1.0.0-rc.5` in `Chart.yaml` and `README.md`.
>   - **Documentation**:
>     - Updates `UPGRADE.md` to reflect new configuration structure for annotations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-k8s&utm_source=github&utm_medium=referral)<sup> for 6abe79b0b531e5da6653b4af2299c2e0919afd55. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->