### PR TITLE
feat: add s3 concurrency options

### DIFF
--- a/charts/langfuse/Chart.yaml
+++ b/charts/langfuse/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: langfuse
-version: 1.0.0-rc.6
+version: 1.0.0-rc.7
 description: Open source LLM engineering platform - LLM observability, metrics, evaluations, prompt management.
 type: application
 keywords:

--- a/charts/langfuse/README.md
+++ b/charts/langfuse/README.md
@@ -189,6 +189,8 @@ Open source LLM engineering platform - LLM observability, metrics, evaluations, 
 | s3.batchExport.region | string | `""` | S3 region to use for batch exports. |
 | s3.batchExport.secretAccessKey | object | `{"secretKeyRef":{"key":"","name":""},"value":""}` | S3 secretAccessKey to use for batch exports. |
 | s3.bucket | string | `""` | S3 bucket to use for all uploads. Can be overridden per upload type. |
+| s3.concurrency.reads | int | `50` | Maximum number of concurrent read operations to S3. Defaults to 50. |
+| s3.concurrency.writes | int | `50` | Maximum number of concurrent write operations to S3. Defaults to 50. |
 | s3.defaultBuckets | string | `"langfuse"` |  |
 | s3.deploy | bool | `true` | Enable MinIO deployment (via Bitnami Helm Chart). If you want to use a custom BlobStorage, e.g. S3, set to false. |
 | s3.endpoint | string | `""` | S3 endpoint to use for all uploads. Can be overridden per upload type. |

--- a/charts/langfuse/README.md
+++ b/charts/langfuse/README.md
@@ -1,6 +1,6 @@
 # langfuse
 
-![Version: 1.0.0-rc.6](https://img.shields.io/badge/Version-1.0.0--rc.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.29.1](https://img.shields.io/badge/AppVersion-3.29.1-informational?style=flat-square)
+![Version: 1.0.0-rc.7](https://img.shields.io/badge/Version-1.0.0--rc.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.29.1](https://img.shields.io/badge/AppVersion-3.29.1-informational?style=flat-square)
 
 Open source LLM engineering platform - LLM observability, metrics, evaluations, prompt management.
 

--- a/charts/langfuse/templates/_helpers.tpl
+++ b/charts/langfuse/templates/_helpers.tpl
@@ -452,6 +452,16 @@ Get value of a specific environment variable from additionalEnv if it exists
   value: {{ .Values.s3.mediaUpload.maxContentLength | quote }}
 - name: LANGFUSE_S3_MEDIA_UPLOAD_DOWNLOAD_URL_EXPIRY_SECONDS
   value: {{ .Values.s3.mediaUpload.downloadUrlExpirySeconds | quote }}
+{{- if hasKey .Values.s3 "concurrency" }}
+{{- if hasKey .Values.s3.concurrency "reads" }}
+- name: LANGFUSE_S3_CONCURRENT_READS
+  value: {{ .Values.s3.concurrency.reads | quote }}
+{{- end }}
+{{- if hasKey .Values.s3.concurrency "writes" }}
+- name: LANGFUSE_S3_CONCURRENT_WRITES
+  value: {{ .Values.s3.concurrency.writes | quote }}
+{{- end }}
+{{- end }}
 {{- end -}}
 
 {{/*

--- a/charts/langfuse/values.yaml
+++ b/charts/langfuse/values.yaml
@@ -440,6 +440,13 @@ s3:
       name: ""
       key: ""
 
+  # S3 Concurrency Configuration
+  concurrency:
+    # -- Maximum number of concurrent read operations to S3. Defaults to 50.
+    reads: 50
+    # -- Maximum number of concurrent write operations to S3. Defaults to 50.
+    writes: 50
+
   # Event Upload Configuration
   eventUpload:
     # -- S3 bucket to use for event uploads.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add S3 concurrency options for read and write operations with default values of 50, and update version to 1.0.0-rc.7.
> 
>   - **S3 Concurrency Options**:
>     - Added `s3.concurrency.reads` and `s3.concurrency.writes` to `values.yaml` with default values of 50.
>     - Updated `_helpers.tpl` to include `LANGFUSE_S3_CONCURRENT_READS` and `LANGFUSE_S3_CONCURRENT_WRITES` environment variables.
>   - **Version Update**:
>     - Updated version to 1.0.0-rc.7 in `Chart.yaml` and `README.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-k8s&utm_source=github&utm_medium=referral)<sup> for ce7cf23b13f9b9dd19309134c7317f4015f24087. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->