### PR TITLE
fix: overwrite region default for eventUpload

### DIFF
--- a/charts/langfuse/Chart.yaml
+++ b/charts/langfuse/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: langfuse
-version: 1.0.0-rc.8
+version: 1.0.0-rc.9
 description: Open source LLM engineering platform - LLM observability, metrics, evaluations, prompt management.
 type: application
 keywords:

--- a/charts/langfuse/README.md
+++ b/charts/langfuse/README.md
@@ -1,6 +1,6 @@
 # langfuse
 
-![Version: 1.0.0-rc.8](https://img.shields.io/badge/Version-1.0.0--rc.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.29.1](https://img.shields.io/badge/AppVersion-3.29.1-informational?style=flat-square)
+![Version: 1.0.0-rc.9](https://img.shields.io/badge/Version-1.0.0--rc.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.29.1](https://img.shields.io/badge/AppVersion-3.29.1-informational?style=flat-square)
 
 Open source LLM engineering platform - LLM observability, metrics, evaluations, prompt management.
 
@@ -199,7 +199,7 @@ Open source LLM engineering platform - LLM observability, metrics, evaluations, 
 | s3.eventUpload.endpoint | string | `""` | S3 endpoint to use for event uploads. |
 | s3.eventUpload.forcePathStyle | bool | `true` | Whether to force path style on requests. Required for MinIO. |
 | s3.eventUpload.prefix | string | `""` | Prefix to use for event uploads within the bucket. |
-| s3.eventUpload.region | string | `"auto"` | S3 region to use for event uploads. |
+| s3.eventUpload.region | string | `""` | S3 region to use for event uploads. |
 | s3.eventUpload.secretAccessKey | object | `{"secretKeyRef":{"key":"","name":""},"value":""}` | S3 secretAccessKey to use for event uploads. |
 | s3.forcePathStyle | bool | `true` | Whether to force path style on requests. Required for MinIO. Can be overridden per upload type. |
 | s3.mediaUpload.accessKeyId | object | `{"secretKeyRef":{"key":"","name":""},"value":""}` | S3 accessKeyId to use for media uploads. |

--- a/charts/langfuse/values.yaml
+++ b/charts/langfuse/values.yaml
@@ -454,7 +454,7 @@ s3:
     # -- Prefix to use for event uploads within the bucket.
     prefix: ""
     # -- S3 region to use for event uploads.
-    region: "auto"
+    region: ""
     # -- S3 endpoint to use for event uploads.
     endpoint: ""
     # -- Whether to force path style on requests. Required for MinIO.


### PR DESCRIPTION
Fixes https://github.com/langfuse/langfuse-k8s/issues/93
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change default S3 region for `eventUpload` to empty string and update version to 1.0.0-rc.9.
> 
>   - **Behavior**:
>     - Default S3 region for `eventUpload` changed from `"auto"` to `""` in `values.yaml`.
>   - **Documentation**:
>     - Updated `README.md` to reflect the new default S3 region for `eventUpload`.
>   - **Versioning**:
>     - Bumped version from 1.0.0-rc.8 to 1.0.0-rc.9 in `Chart.yaml` and `README.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-k8s&utm_source=github&utm_medium=referral)<sup> for a06c1a99be8218454bfca6e70d219d695ec08aee. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->