### PR TITLE
Fix web deployment yaml when clickhouse.replicaCount set to 1

### DIFF
--- a/charts/langfuse/templates/_helpers.tpl
+++ b/charts/langfuse/templates/_helpers.tpl
@@ -296,7 +296,7 @@ Get value of a specific environment variable from additionalEnv if it exists
 {{- else }}
   value: {{ required "Configuring an existing secret or clickhouse.auth.password is required" .Values.clickhouse.auth.password | quote }}
 {{- end }}
-{{- if $.Values.clickhouse.replicaCount | int | eq 1 -}}
+{{- if $.Values.clickhouse.replicaCount | int | eq 1 }}
 - name: CLICKHOUSE_CLUSTER_ENABLED
   value: "false"
 {{- end }}


### PR DESCRIPTION
when clickhouse.replicaCount is set to 1 to disable clickhouse cluster. There will be an format error in web deployment yaml.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes formatting error in `charts/langfuse/templates/_helpers.tpl` for `clickhouse.replicaCount` set to 1, ensuring `CLICKHOUSE_CLUSTER_ENABLED` is set to `false`.
> 
>   - **Fix**:
>     - Corrects formatting error in `charts/langfuse/templates/_helpers.tpl` when `clickhouse.replicaCount` is set to 1.
>     - Ensures `CLICKHOUSE_CLUSTER_ENABLED` is set to `false` in this case.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-k8s&utm_source=github&utm_medium=referral)<sup> for 1b19a7632f28c82d74d60f5ad11a6cf04c4319ad. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->