### PR TITLE
Keda

### DIFF
--- a/charts/langfuse/README.md
+++ b/charts/langfuse/README.md
@@ -97,6 +97,14 @@ Open source LLM engineering platform - LLM observability, metrics, evaluations, 
 | langfuse.web.image.pullSecrets | string | `nil` | The pull secrets to use for the langfuse web pods. Using `langfuse.image.pullSecrets` if not set. |
 | langfuse.web.image.repository | string | `"langfuse/langfuse"` | The image repository to use for the langfuse web pods. |
 | langfuse.web.image.tag | string | `nil` | The tag to use for the langfuse web pods. Using `langfuse.image.tag` if not set. |
+| langfuse.web.keda.containerName | string | `""` | Optional container name to target for metrics (leave empty to target all containers) |
+| langfuse.web.keda.enabled | bool | `false` | Set to `true` to enable KEDA for the langfuse web pods. Note: When both KEDA and HPA are enabled, KEDA will take precedence and HPA will be ignored. |
+| langfuse.web.keda.maxReplicas | int | `2` | The maximum number of replicas to use for the langfuse web pods |
+| langfuse.web.keda.metricType | string | `"Utilization"` | The metric type for scaling (Utilization or AverageValue) |
+| langfuse.web.keda.minReplicas | int | `1` | The minimum number of replicas to use for the langfuse web pods |
+| langfuse.web.keda.pollingInterval | int | `30` | The polling interval in seconds for checking metrics |
+| langfuse.web.keda.triggerType | string | `"cpu"` | The trigger type for scaling (cpu or memory) |
+| langfuse.web.keda.value | string | `"50"` | The target utilization percentage for the langfuse web pods |
 | langfuse.web.livenessProbe.failureThreshold | int | `3` | Failure threshold for livenessProbe. |
 | langfuse.web.livenessProbe.initialDelaySeconds | int | `20` | Initial delay seconds for livenessProbe. |
 | langfuse.web.livenessProbe.path | string | `"/api/public/health"` | Path to check for liveness. |
@@ -132,6 +140,14 @@ Open source LLM engineering platform - LLM observability, metrics, evaluations, 
 | langfuse.worker.image.pullSecrets | string | `nil` | The pull secrets to use for the langfuse worker pods. Using `langfuse.image.pullSecrets` if not set. |
 | langfuse.worker.image.repository | string | `"langfuse/langfuse-worker"` | The image repository to use for the langfuse worker pods |
 | langfuse.worker.image.tag | string | `nil` | The tag to use for the langfuse worker pods. Using `langfuse.image.tag` if not set. |
+| langfuse.worker.keda.containerName | string | `""` | Optional container name to target for metrics (leave empty to target all containers) |
+| langfuse.worker.keda.enabled | bool | `false` | Set to `true` to enable KEDA for the langfuse worker pods. Note: When both KEDA and HPA are enabled, KEDA will take precedence and HPA will be ignored. |
+| langfuse.worker.keda.maxReplicas | int | `2` | The maximum number of replicas to use for the langfuse worker pods |
+| langfuse.worker.keda.metricType | string | `"Utilization"` | The metric type for scaling (Utilization or AverageValue) |
+| langfuse.worker.keda.minReplicas | int | `1` | The minimum number of replicas to use for the langfuse worker pods |
+| langfuse.worker.keda.pollingInterval | int | `30` | The polling interval in seconds for checking metrics |
+| langfuse.worker.keda.triggerType | string | `"cpu"` | The trigger type for scaling (cpu or memory) |
+| langfuse.worker.keda.value | string | `"50"` | The target utilization percentage for the langfuse worker pods |
 | langfuse.worker.livenessProbe.failureThreshold | int | `3` | Failure threshold for livenessProbe. |
 | langfuse.worker.livenessProbe.initialDelaySeconds | int | `20` | Initial delay seconds for livenessProbe. |
 | langfuse.worker.livenessProbe.periodSeconds | int | `10` | Period seconds for livenessProbe. |

--- a/charts/langfuse/templates/web/deployment.yaml
+++ b/charts/langfuse/templates/web/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if not .Values.langfuse.web.hpa.enabled }}
+  {{- if not (or .Values.langfuse.web.hpa.enabled .Values.langfuse.web.keda.enabled) }}
   replicas: {{ .Values.langfuse.web.replicas | default .Values.langfuse.replicas }}
   {{- end }}
   {{- if .Values.langfuse.web.hostAliases }}

--- a/charts/langfuse/templates/web/hpa.yaml
+++ b/charts/langfuse/templates/web/hpa.yaml
@@ -1,4 +1,4 @@
-{{- if ((.Values.langfuse.web).hpa).enabled }}
+{{- if and ((.Values.langfuse.web).hpa).enabled (not ((.Values.langfuse.web).keda).enabled) }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/charts/langfuse/templates/web/scaled-object.yaml
+++ b/charts/langfuse/templates/web/scaled-object.yaml
@@ -1,4 +1,4 @@
-{{- if and ((.Values.langfuse.web).keda).enabled (not ((.Values.langfuse.web).hpa).enabled) }}
+{{- if ((.Values.langfuse.web).keda).enabled }}
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
@@ -12,11 +12,11 @@ spec:
   maxReplicaCount: {{ .Values.langfuse.web.keda.maxReplicas }}
   pollingInterval: {{ .Values.langfuse.web.keda.pollingInterval }}
   triggers:
-    - type: cpu
-      metricType: {{ .Values.langfuse.web.keda.cpu.metricType }}
+    - type: {{ .Values.langfuse.web.keda.triggerType }}
+      metricType: {{ .Values.langfuse.web.keda.metricType }}
       metadata:
-        value: "{{ .Values.langfuse.web.keda.cpu.value }}"
-        {{- if .Values.langfuse.web.keda.cpu.containerName }}
-        containerName: "{{ .Values.langfuse.web.keda.cpu.containerName }}"
+        value: "{{ .Values.langfuse.web.keda.value }}"
+        {{- if .Values.langfuse.web.keda.containerName }}
+        containerName: "{{ .Values.langfuse.web.keda.containerName }}"
         {{- end }}
 {{- end }}

--- a/charts/langfuse/templates/web/scaled-object.yaml
+++ b/charts/langfuse/templates/web/scaled-object.yaml
@@ -11,7 +11,6 @@ spec:
   minReplicaCount: {{ .Values.langfuse.web.keda.minReplicas }}
   maxReplicaCount: {{ .Values.langfuse.web.keda.maxReplicas }}
   pollingInterval: {{ .Values.langfuse.web.keda.pollingInterval }}
-  cooldownPeriod: {{ .Values.langfuse.web.keda.cooldownPeriod }}
   triggers:
     - type: cpu
       metricType: {{ .Values.langfuse.web.keda.cpu.metricType }}

--- a/charts/langfuse/templates/web/scaled-object.yaml
+++ b/charts/langfuse/templates/web/scaled-object.yaml
@@ -1,0 +1,23 @@
+{{- if and ((.Values.langfuse.web).keda).enabled (not ((.Values.langfuse.web).hpa).enabled) }}
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: {{ include "langfuse.fullname" . }}-web
+  labels:
+    {{- include "langfuse.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    name: {{ include "langfuse.fullname" . }}-web
+  minReplicaCount: {{ .Values.langfuse.web.keda.minReplicas }}
+  maxReplicaCount: {{ .Values.langfuse.web.keda.maxReplicas }}
+  pollingInterval: {{ .Values.langfuse.web.keda.pollingInterval }}
+  cooldownPeriod: {{ .Values.langfuse.web.keda.cooldownPeriod }}
+  triggers:
+    - type: cpu
+      metricType: {{ .Values.langfuse.web.keda.cpu.metricType }}
+      metadata:
+        value: "{{ .Values.langfuse.web.keda.cpu.value }}"
+        {{- if .Values.langfuse.web.keda.cpu.containerName }}
+        containerName: "{{ .Values.langfuse.web.keda.cpu.containerName }}"
+        {{- end }}
+{{- end }}

--- a/charts/langfuse/templates/worker/deployment.yaml
+++ b/charts/langfuse/templates/worker/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if not .Values.langfuse.worker.hpa.enabled }}
+  {{- if not (or .Values.langfuse.worker.hpa.enabled .Values.langfuse.worker.keda.enabled) }}
   replicas: {{ .Values.langfuse.worker.replicas | default .Values.langfuse.replicas }}
   {{- end }}
   selector:

--- a/charts/langfuse/templates/worker/hpa.yaml
+++ b/charts/langfuse/templates/worker/hpa.yaml
@@ -1,4 +1,4 @@
-{{- if ((.Values.langfuse.worker).hpa).enabled }}
+{{- if and ((.Values.langfuse.worker).hpa).enabled (not ((.Values.langfuse.worker).keda).enabled) }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/charts/langfuse/templates/worker/scaled-object.yaml
+++ b/charts/langfuse/templates/worker/scaled-object.yaml
@@ -1,0 +1,22 @@
+{{- if and ((.Values.langfuse.worker).keda).enabled (not ((.Values.langfuse.worker).hpa).enabled) }}
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: {{ include "langfuse.fullname" . }}-worker
+  labels:
+    {{- include "langfuse.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    name: {{ include "langfuse.fullname" . }}-worker
+  minReplicaCount: {{ .Values.langfuse.worker.keda.minReplicas }}
+  maxReplicaCount: {{ .Values.langfuse.worker.keda.maxReplicas }}
+  pollingInterval: {{ .Values.langfuse.worker.keda.pollingInterval }}
+  triggers:
+    - type: cpu
+      metricType: {{ .Values.langfuse.worker.keda.cpu.metricType }}
+      metadata:
+        value: "{{ .Values.langfuse.worker.keda.cpu.value }}"
+        {{- if .Values.langfuse.worker.keda.cpu.containerName }}
+        containerName: "{{ .Values.langfuse.worker.keda.cpu.containerName }}"
+        {{- end }}
+{{- end }}

--- a/charts/langfuse/templates/worker/scaled-object.yaml
+++ b/charts/langfuse/templates/worker/scaled-object.yaml
@@ -1,4 +1,4 @@
-{{- if and ((.Values.langfuse.worker).keda).enabled (not ((.Values.langfuse.worker).hpa).enabled) }}
+{{- if ((.Values.langfuse.worker).keda).enabled }}
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
@@ -12,11 +12,11 @@ spec:
   maxReplicaCount: {{ .Values.langfuse.worker.keda.maxReplicas }}
   pollingInterval: {{ .Values.langfuse.worker.keda.pollingInterval }}
   triggers:
-    - type: cpu
-      metricType: {{ .Values.langfuse.worker.keda.cpu.metricType }}
+    - type: {{ .Values.langfuse.worker.keda.triggerType }}
+      metricType: {{ .Values.langfuse.worker.keda.metricType }}
       metadata:
-        value: "{{ .Values.langfuse.worker.keda.cpu.value }}"
-        {{- if .Values.langfuse.worker.keda.cpu.containerName }}
-        containerName: "{{ .Values.langfuse.worker.keda.cpu.containerName }}"
+        value: "{{ .Values.langfuse.worker.keda.value }}"
+        {{- if .Values.langfuse.worker.keda.containerName }}
+        containerName: "{{ .Values.langfuse.worker.keda.containerName }}"
         {{- end }}
 {{- end }}

--- a/charts/langfuse/values.yaml
+++ b/charts/langfuse/values.yaml
@@ -260,9 +260,30 @@ langfuse:
     # -- Number of replicas to use if HPA is not enabled. Defaults to the global replicas
     replicas: null
 
+    # KEDA ScaledObject configuration
+    keda:
+      # -- Set to `true` to enable KEDA for the langfuse worker pods
+      # Note: KEDA and HPA should not be enabled simultaneously. If both are enabled, HPA will be ignored.
+      enabled: false
+      # -- The minimum number of replicas to use for the langfuse worker pods
+      minReplicas: 1
+      # -- The maximum number of replicas to use for the langfuse worker pods
+      maxReplicas: 2
+      # -- The polling interval in seconds for checking metrics
+      pollingInterval: 30
+      # -- CPU trigger configuration
+      cpu:
+        # -- The metric type for CPU scaling (Utilization or AverageValue)
+        metricType: "Utilization"
+        # -- The target CPU utilization percentage for the langfuse worker pods
+        value: "50"
+        # -- Optional container name to target for CPU metrics (leave empty to target all containers)
+        containerName: ""
+
     # Horizontal Pod Autoscaler configuration
     hpa:
       # -- Set to `true` to enable HPA for the langfuse worker pods
+      # Note: HPA and KEDA should not be enabled simultaneously. If both are enabled, HPA will be ignored.
       enabled: false
       # -- The minimum number of replicas to use for the langfuse worker pods
       minReplicas: 1

--- a/charts/langfuse/values.yaml
+++ b/charts/langfuse/values.yaml
@@ -160,7 +160,7 @@ langfuse:
     # KEDA ScaledObject configuration
     keda:
       # -- Set to `true` to enable KEDA for the langfuse web pods
-      # Note: KEDA and HPA should not be enabled simultaneously. If both are enabled, HPA will be ignored.
+      # Note: When both KEDA and HPA are enabled, KEDA will take precedence and HPA will be ignored.
       enabled: false
       # -- The minimum number of replicas to use for the langfuse web pods
       minReplicas: 1
@@ -168,14 +168,14 @@ langfuse:
       maxReplicas: 2
       # -- The polling interval in seconds for checking metrics
       pollingInterval: 30
-      # -- CPU trigger configuration
-      cpu:
-        # -- The metric type for CPU scaling (Utilization or AverageValue)
-        metricType: "Utilization"
-        # -- The target CPU utilization percentage for the langfuse web pods
-        value: "50"
-        # -- Optional container name to target for CPU metrics (leave empty to target all containers)
-        containerName: ""
+      # -- The trigger type for scaling (cpu or memory)
+      triggerType: "cpu"
+      # -- The metric type for scaling (Utilization or AverageValue)
+      metricType: "Utilization"
+      # -- The target utilization percentage for the langfuse web pods
+      value: "50"
+      # -- Optional container name to target for metrics (leave empty to target all containers)
+      containerName: ""
 
     # Horizontal Pod Autoscaler configuration
     hpa:
@@ -263,7 +263,7 @@ langfuse:
     # KEDA ScaledObject configuration
     keda:
       # -- Set to `true` to enable KEDA for the langfuse worker pods
-      # Note: KEDA and HPA should not be enabled simultaneously. If both are enabled, HPA will be ignored.
+      # Note: When both KEDA and HPA are enabled, KEDA will take precedence and HPA will be ignored.
       enabled: false
       # -- The minimum number of replicas to use for the langfuse worker pods
       minReplicas: 1
@@ -271,14 +271,14 @@ langfuse:
       maxReplicas: 2
       # -- The polling interval in seconds for checking metrics
       pollingInterval: 30
-      # -- CPU trigger configuration
-      cpu:
-        # -- The metric type for CPU scaling (Utilization or AverageValue)
-        metricType: "Utilization"
-        # -- The target CPU utilization percentage for the langfuse worker pods
-        value: "50"
-        # -- Optional container name to target for CPU metrics (leave empty to target all containers)
-        containerName: ""
+      # -- The trigger type for scaling (cpu or memory)
+      triggerType: "cpu"
+      # -- The metric type for scaling (Utilization or AverageValue)
+      metricType: "Utilization"
+      # -- The target utilization percentage for the langfuse worker pods
+      value: "50"
+      # -- Optional container name to target for metrics (leave empty to target all containers)
+      containerName: ""
 
     # Horizontal Pod Autoscaler configuration
     hpa:

--- a/charts/langfuse/values.yaml
+++ b/charts/langfuse/values.yaml
@@ -160,6 +160,7 @@ langfuse:
     # Horizontal Pod Autoscaler configuration
     hpa:
       # -- Set to `true` to enable HPA for the langfuse web pods
+      # Note: HPA and KEDA should not be enabled simultaneously. If both are enabled, HPA will be ignored.
       enabled: false
       # -- The minimum number of replicas to use for the langfuse web pods
       minReplicas: 1
@@ -167,6 +168,28 @@ langfuse:
       maxReplicas: 2
       # -- The target CPU utilization percentage for the langfuse web pods
       targetCPUUtilizationPercentage: 50
+
+    # KEDA ScaledObject configuration
+    keda:
+      # -- Set to `true` to enable KEDA for the langfuse web pods
+      # Note: KEDA and HPA should not be enabled simultaneously. If both are enabled, HPA will be ignored.
+      enabled: false
+      # -- The minimum number of replicas to use for the langfuse web pods
+      minReplicas: 1
+      # -- The maximum number of replicas to use for the langfuse web pods
+      maxReplicas: 2
+      # -- The polling interval in seconds for checking metrics
+      pollingInterval: 30
+      # -- The cool down period in seconds after scaling down
+      cooldownPeriod: 300
+      # -- CPU trigger configuration
+      cpu:
+        # -- The metric type for CPU scaling (Utilization or AverageValue)
+        metricType: "Utilization"
+        # -- The target CPU utilization percentage for the langfuse web pods
+        value: "50"
+        # -- Optional container name to target for CPU metrics (leave empty to target all containers)
+        containerName: ""
 
     # Vertical Pod Autoscaler configuration
     vpa:

--- a/charts/langfuse/values.yaml
+++ b/charts/langfuse/values.yaml
@@ -157,18 +157,6 @@ langfuse:
     # -- Number of replicas to use if HPA is not enabled. Defaults to the global replicas
     replicas: null
 
-    # Horizontal Pod Autoscaler configuration
-    hpa:
-      # -- Set to `true` to enable HPA for the langfuse web pods
-      # Note: HPA and KEDA should not be enabled simultaneously. If both are enabled, HPA will be ignored.
-      enabled: false
-      # -- The minimum number of replicas to use for the langfuse web pods
-      minReplicas: 1
-      # -- The maximum number of replicas to use for the langfuse web pods
-      maxReplicas: 2
-      # -- The target CPU utilization percentage for the langfuse web pods
-      targetCPUUtilizationPercentage: 50
-
     # KEDA ScaledObject configuration
     keda:
       # -- Set to `true` to enable KEDA for the langfuse web pods
@@ -180,8 +168,6 @@ langfuse:
       maxReplicas: 2
       # -- The polling interval in seconds for checking metrics
       pollingInterval: 30
-      # -- The cool down period in seconds after scaling down
-      cooldownPeriod: 300
       # -- CPU trigger configuration
       cpu:
         # -- The metric type for CPU scaling (Utilization or AverageValue)
@@ -190,6 +176,18 @@ langfuse:
         value: "50"
         # -- Optional container name to target for CPU metrics (leave empty to target all containers)
         containerName: ""
+
+    # Horizontal Pod Autoscaler configuration
+    hpa:
+      # -- Set to `true` to enable HPA for the langfuse web pods
+      # Note: HPA and KEDA should not be enabled simultaneously. If both are enabled, HPA will be ignored.
+      enabled: false
+      # -- The minimum number of replicas to use for the langfuse web pods
+      minReplicas: 1
+      # -- The maximum number of replicas to use for the langfuse web pods
+      maxReplicas: 2
+      # -- The target CPU utilization percentage for the langfuse web pods
+      targetCPUUtilizationPercentage: 50
 
     # Vertical Pod Autoscaler configuration
     vpa:


### PR DESCRIPTION
# Add KEDA autoscaling support for Langfuse components

This PR adds KEDA (Kubernetes Event-driven Autoscaling) support for both Langfuse web and worker components, providing more flexible autoscaling options beyond the standard Horizontal Pod Autoscaler (HPA).

## Changes

- Added KEDA configuration for both web and worker components.
- Ensured mutual exclusivity between KEDA and HPA
