### PR TITLE
chore: document use of custom storage classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,39 @@ langfuse:
     annotations: []
 ```
 
+#### Custom Storage Class Definition
+
+The Langfuse chart supports configuring storage classes for all persistent volumes in the deployment. You can configure storage classes in two ways:
+
+1. **Global Storage Class**: Set a global storage class that will be used for all persistent volumes unless overridden.
+```yaml
+global:
+  defaultStorageClass: "your-storage-class"
+```
+
+2. **Component-specific Storage Classes**: Override the storage class for specific components.
+```yaml
+postgresql:
+  primary:
+    persistence:
+      storageClass: "postgres-storage-class"
+   
+redis:
+  primary:
+    persistence:
+      storageClass: "redis-storage-class"
+
+clickhouse:
+  persistence:
+    storageClass: "clickhouse-storage-class"
+
+s3:
+  persistence:
+    storageClass: "minio-storage-class"
+```
+
+If no storage class is specified, the cluster's default storage class will be used.
+
 ##### With an external Postgres server with client certificates using own secrets and additionalEnv for mappings
 
 ```yaml

--- a/charts/langfuse/README.md
+++ b/charts/langfuse/README.md
@@ -155,9 +155,9 @@ Open source LLM engineering platform - LLM observability, metrics, evaluations, 
 | postgresql.auth.password | string | `""` | Password to use to connect to the postgres database deployed with Langfuse. In case `postgresql.deploy` is set to `true`, the password will be set automatically. |
 | postgresql.auth.secretKeys | object | `{"userPasswordKey":"password"}` | The key in the existing secret that contains the password. |
 | postgresql.auth.username | string | `"postgres"` | Username to use to connect to the postgres database deployed with Langfuse. In case `postgresql.deploy` is set to `true`, the user will be created automatically. |
-| postgresql.deploy | bool | `true` | Deploy subchart or use external database |
+| postgresql.deploy | bool | `true` | Enable PostgreSQL deployment (via Bitnami Helm Chart). If you want to use an external Postgres server (or a managed one), set this to false |
 | postgresql.directUrl | string | `""` | If `postgresql.deploy` is set to false, Connection string of your Postgres database used for database migrations. Use this if you want to use a different user for migrations or use connection pooling on DATABASE_URL. For large deployments, configure the database user with long timeouts as migrations might need a while to complete. |
-| postgresql.host | string | `""` | Hostname of the postgres server to use. If `postgresql.deploy` is true, this will be set automatically based on the release name. |
+| postgresql.host | string | `""` | PostgreSQL host to connect to. If postgresql.deploy is true, this will be set automatically based on the release name. |
 | postgresql.migration.autoMigrate | bool | `true` | Whether to run automatic migrations on startup |
 | postgresql.port | string | `nil` | Port of the postgres server to use. Defaults to 5432. |
 | postgresql.primary.service.ports.postgresql | int | `5432` |  |

--- a/charts/langfuse/values.yaml
+++ b/charts/langfuse/values.yaml
@@ -289,10 +289,10 @@ langfuse:
 
 # PostgreSQL Configuration
 postgresql:
-  # -- Deploy subchart or use external database
+  # -- Enable PostgreSQL deployment (via Bitnami Helm Chart). If you want to use an external Postgres server (or a managed one), set this to false
   deploy: true
   
-  # -- Hostname of the postgres server to use. If `postgresql.deploy` is true, this will be set automatically based on the release name.
+  # -- PostgreSQL host to connect to. If postgresql.deploy is true, this will be set automatically based on the release name.
   host: ""
   # -- Port of the postgres server to use. Defaults to 5432.
   port: null
@@ -364,7 +364,7 @@ redis:
     existingSecretPasswordKey: ""
 
     database: 0
-  
+
   # Subchart specific settings
   architecture: standalone
   primary:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds documentation for configuring custom storage classes in the Langfuse Helm chart.
> 
>   - **Documentation**:
>     - Adds section on configuring custom storage classes in `README.md`.
>     - Describes global and component-specific storage class configurations for `postgresql`, `redis`, `clickhouse`, and `s3`.
>     - Clarifies default behavior when no storage class is specified.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-k8s&utm_source=github&utm_medium=referral)<sup> for c7fa4b26c270efaa64ea5158f360004107a1df9c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->