### PR TITLE
updated clickhouse helm chart version

### DIFF
--- a/charts/langfuse/Chart.yaml
+++ b/charts/langfuse/Chart.yaml
@@ -19,7 +19,7 @@ dependencies:
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: postgresql.deploy
   - name: clickhouse
-    version: 7.2.0
+    version: 8.0.5
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: clickhouse.deploy
   - name: valkey

--- a/charts/langfuse/Chart.yaml
+++ b/charts/langfuse/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: langfuse
-version: 1.0.0-rc.12
+version: 1.0.0-rc.13
 description: Open source LLM engineering platform - LLM observability, metrics, evaluations, prompt management.
 type: application
 keywords:

--- a/charts/langfuse/README.md
+++ b/charts/langfuse/README.md
@@ -21,7 +21,7 @@ Open source LLM engineering platform - LLM observability, metrics, evaluations, 
 
 | Repository | Name | Version |
 |------------|------|---------|
-| oci://registry-1.docker.io/bitnamicharts | clickhouse | 7.2.0 |
+| oci://registry-1.docker.io/bitnamicharts | clickhouse | 8.0.5 |
 | oci://registry-1.docker.io/bitnamicharts | common | 2.30.0 |
 | oci://registry-1.docker.io/bitnamicharts | s3(minio) | 14.10.5 |
 | oci://registry-1.docker.io/bitnamicharts | postgresql | 16.4.9 |

--- a/charts/langfuse/README.md
+++ b/charts/langfuse/README.md
@@ -1,6 +1,6 @@
 # langfuse
 
-![Version: 1.0.0-rc.12](https://img.shields.io/badge/Version-1.0.0--rc.12-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.29.1](https://img.shields.io/badge/AppVersion-3.29.1-informational?style=flat-square)
+![Version: 1.0.0-rc.13](https://img.shields.io/badge/Version-1.0.0--rc.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.38.0](https://img.shields.io/badge/AppVersion-3.29.1-informational?style=flat-square)
 
 Open source LLM engineering platform - LLM observability, metrics, evaluations, prompt management.
 

--- a/charts/langfuse/README.md
+++ b/charts/langfuse/README.md
@@ -1,6 +1,6 @@
 # langfuse
 
-![Version: 1.0.0-rc.13](https://img.shields.io/badge/Version-1.0.0--rc.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.38.0](https://img.shields.io/badge/AppVersion-3.29.1-informational?style=flat-square)
+![Version: 1.0.0-rc.13](https://img.shields.io/badge/Version-1.0.0--rc.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.38.0](https://img.shields.io/badge/AppVersion-3.38.0-informational?style=flat-square)
 
 Open source LLM engineering platform - LLM observability, metrics, evaluations, prompt management.
 


### PR DESCRIPTION
There are no breaking changes between ClickHouse Helm chart versions 7.2.0 and 8.0.5.
The ClickHouse version has been updated from clickhouse24.12.3-debian-12-r1 to clickhouse:25.2.1-debian-12-r0.

Changelog: https://github.com/bitnami/charts/blob/main/bitnami/clickhouse/CHANGELOG.md
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update ClickHouse Helm chart version to 8.0.5 and ClickHouse version to 25.2.1-debian-12-r0 in `langfuse` chart.
> 
>   - **Dependencies**:
>     - Update ClickHouse Helm chart version from 7.2.0 to 8.0.5 in `Chart.yaml` and `README.md`.
>   - **ClickHouse Version**:
>     - Update ClickHouse version from `clickhouse24.12.3-debian-12-r1` to `clickhouse:25.2.1-debian-12-r0`.
>   - **Documentation**:
>     - Reflect version change in `README.md` dependency table.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-k8s&utm_source=github&utm_medium=referral)<sup> for d40352302eb6318fc9f42ce7cdb0a1931aba3624. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->