### PR TITLE
Add the value rootUserSecretKey as indication

### DIFF
--- a/charts/langfuse/values.yaml
+++ b/charts/langfuse/values.yaml
@@ -593,6 +593,8 @@ s3:
     rootPassword: ""
     # -- If you want to use an existing secret for the root user password, set the name of the secret here. (`s3.auth.rootUser` and `s3.auth.rootPassword` will be ignored and picked up from this secret).
     existingSecret: ""
+    # -- Key where the Minio root user name is being stored inside the existing secret `s3.auth.existingSecret`
+    rootUserSecretKey: ""
     # -- Key where the Minio root user password is being stored inside the existing secret `s3.auth.existingSecret`
     rootPasswordSecretKey: ""
 


### PR DESCRIPTION
For minio, when using a secret both username and password have to come from the secret. It will help to know how to specify the key in the secretfor the username as well.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `rootUserSecretKey` to specify Minio root username key in existing secret in `charts/langfuse/values.yaml`.
> 
>   - **Configuration**:
>     - Adds `rootUserSecretKey` to `charts/langfuse/values.yaml` for specifying the key of the Minio root username in an existing secret.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-k8s&utm_source=github&utm_medium=referral)<sup> for ed650277bd77bf295fca508f24ade13f98173ced. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->