### PR TITLE
feat: allow empty redis username

### DIFF
--- a/charts/langfuse/Chart.yaml
+++ b/charts/langfuse/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: langfuse
-version: 1.1.0
+version: 1.2.0
 description: Open source LLM engineering platform - LLM observability, metrics, evaluations, prompt management.
 type: application
 keywords:
@@ -40,4 +40,4 @@ maintainers:
     email: contact@langfuse.com
     url: https://langfuse.com/
 icon: https://langfuse.com/langfuse_logo.png
-appVersion: "3.43.0"
+appVersion: "3.48.0"

--- a/charts/langfuse/README.md
+++ b/charts/langfuse/README.md
@@ -1,6 +1,6 @@
 # langfuse
 
-![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.43.0](https://img.shields.io/badge/AppVersion-3.43.0-informational?style=flat-square)
+![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.48.0](https://img.shields.io/badge/AppVersion-3.48.0-informational?style=flat-square)
 
 Open source LLM engineering platform - LLM observability, metrics, evaluations, prompt management.
 

--- a/charts/langfuse/README.md
+++ b/charts/langfuse/README.md
@@ -189,6 +189,7 @@ Open source LLM engineering platform - LLM observability, metrics, evaluations, 
 | redis.auth.existingSecret | string | `""` | If you want to use an existing secret for the redis password, set the name of the secret here. (`redis.auth.password` will be ignored and picked up from this secret). |
 | redis.auth.existingSecretPasswordKey | string | `""` | The key in the existing secret that contains the password. |
 | redis.auth.password | string | `""` | Configure the password by value or existing secret reference |
+| redis.auth.username | string | `"default"` | Username to use to connect to the redis database deployed with Langfuse. In case `redis.deploy` is set to `true`, the user will be created automatically. Set to null for an empty username in the connection string. |
 | redis.deploy | bool | `true` | Enable valkey deployment (via Bitnami Helm Chart). If you want to use a Redis or Valkey server already deployed, set to false. |
 | redis.host | string | `""` | Redis host to connect to. If redis.deploy is true, this will be set automatically based on the release name. |
 | redis.port | int | `6379` | Redis port to connect to. |

--- a/charts/langfuse/templates/_helpers.tpl
+++ b/charts/langfuse/templates/_helpers.tpl
@@ -258,7 +258,7 @@ Get value of a specific environment variable from additionalEnv if it exists
 - name: REDIS_TLS_ENABLED
   value: {{ .Values.redis.tls.enabled | quote }}
 - name: REDIS_CONNECTION_STRING
-  value: "{{ if .Values.redis.tls.enabled }}rediss{{ else }}redis{{ end }}://{{ .Values.redis.auth.username | default "default" }}:$(REDIS_PASSWORD)@{{ include "langfuse.redis.hostname" . }}:{{ .Values.redis.port }}/{{ .Values.redis.auth.database }}"
+  value: "{{ if .Values.redis.tls.enabled }}rediss{{ else }}redis{{ end }}://{{ .Values.redis.auth.username }}:$(REDIS_PASSWORD)@{{ include "langfuse.redis.hostname" . }}:{{ .Values.redis.port }}/{{ .Values.redis.auth.database }}"
 {{- if .Values.redis.tls.enabled }}
 {{- if .Values.redis.tls.caPath }}
 - name: REDIS_TLS_CA_PATH

--- a/charts/langfuse/values.yaml
+++ b/charts/langfuse/values.yaml
@@ -21,7 +21,7 @@ langfuse:
     secretKeyRef:
       name: ""
       key: ""
-  
+
   # -- Langfuse EE license key.
   licenseKey:
     value: ""
@@ -44,7 +44,7 @@ langfuse:
     signUpDisabled: false
     # -- Enable experimental features
     experimentalFeaturesEnabled: false
-  
+
   # -- Node.js environment to use for all langfuse deployments
   nodeEnv: production
 
@@ -210,7 +210,7 @@ langfuse:
       updatePolicy:
         # -- The update policy mode for the langfuse web pods
         updateMode: Auto
-    
+
     # -- Adding records to /etc/hosts in the pod's network.
     hostAliases: []
 
@@ -241,7 +241,7 @@ langfuse:
       failureThreshold: 3
       # -- Success threshold for readinessProbe.
       successThreshold: 1
-  
+
   # Worker deployment configuration
   worker:
     image:
@@ -317,7 +317,7 @@ langfuse:
       updatePolicy:
         # -- The update policy mode for the langfuse worker pods
         updateMode: Auto
-    
+
     livenessProbe:
       # -- Initial delay seconds for livenessProbe.
       initialDelaySeconds: 20
@@ -345,7 +345,7 @@ langfuse:
 postgresql:
   # -- Enable PostgreSQL deployment (via Bitnami Helm Chart). If you want to use an external Postgres server (or a managed one), set this to false
   deploy: true
-  
+
   # -- PostgreSQL host to connect to. If postgresql.deploy is true, this will be set automatically based on the release name.
   host: ""
   # -- Port of the postgres server to use. Defaults to 5432.
@@ -374,7 +374,7 @@ postgresql:
     database: postgres_langfuse
     # -- Additional database connection arguments
     args: ""
-  
+
   # Migration configuration
   migration:
     # -- Whether to run automatic migrations on startup
@@ -396,7 +396,7 @@ redis:
   host: ""
   # -- Redis port to connect to.
   port: 6379
-  
+
   # Redis TLS configuration
   tls:
     # -- Set to `true` to enable TLS/SSL encrypted connection to the Redis server
@@ -407,9 +407,11 @@ redis:
     certPath: ""
     # -- Path to the client private key file for mutual TLS authentication
     keyPath: ""
-  
+
   # Authentication configuration
   auth:
+    # -- Username to use to connect to the redis database deployed with Langfuse. In case `redis.deploy` is set to `true`, the user will be created automatically. Set to null for an empty username in the connection string.
+    username: "default"
     # -- Configure the password by value or existing secret reference
     password: ""
     # -- If you want to use an existing secret for the redis password, set the name of the secret here. (`redis.auth.password` will be ignored and picked up from this secret).
@@ -430,14 +432,14 @@ redis:
 clickhouse:
   # -- Enable ClickHouse deployment (via Bitnami Helm Chart). If you want to use an external Clickhouse server (or a managed one), set this to false
   deploy: true
-  
+
   # -- ClickHouse host to connect to. If clickhouse.deploy is true, this will be set automatically based on the release name.
   host: ""
   # -- ClickHouse HTTP port to connect to.
   httpPort: 8123
   # -- ClickHouse native port to connect to.
   nativePort: 9000
-  
+
   # Authentication configuration
   auth:
     # -- Username for the ClickHouse user.
@@ -448,7 +450,7 @@ clickhouse:
     existingSecret: ""
     # -- The key in the existing secret that contains the password.
     existingSecretKey: ""
-  
+
   # Migration configuration
   migration:
     # -- Migration URL (TCP protocol) for clickhouse


### PR DESCRIPTION
Fixes https://github.com/langfuse/langfuse-k8s/issues/118
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Allow empty Redis username by setting `redis.auth.username` to null, and update chart and app versions.
> 
>   - **Behavior**:
>     - Allow `redis.auth.username` to be set to null for an empty username in the connection string in `values.yaml` and `_helpers.tpl`.
>   - **Version Updates**:
>     - Update chart version to `1.2.0` and app version to `3.48.0` in `Chart.yaml` and `README.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-k8s&utm_source=github&utm_medium=referral)<sup> for ce22e039e8a3c774961327cae123aabf492a8b62. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->