### PR TITLE
fix: propagate s3.auth.rootUserSecretKey to langfuse containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,9 @@ redis:
 
 s3:
   auth:
+    # If existingSecret is set, both root user and root password must be supplied via the secret
     existingSecret: langfuse-s3-auth
+    rootUserSecretKey: rootUser
     rootPasswordSecretKey: rootPassword
 ```
       

--- a/charts/langfuse/Chart.yaml
+++ b/charts/langfuse/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: langfuse
-version: 1.2.0
+version: 1.2.1
 description: Open source LLM engineering platform - LLM observability, metrics, evaluations, prompt management.
 type: application
 keywords:

--- a/charts/langfuse/README.md
+++ b/charts/langfuse/README.md
@@ -1,6 +1,6 @@
 # langfuse
 
-![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.48.0](https://img.shields.io/badge/AppVersion-3.48.0-informational?style=flat-square)
+![Version: 1.2.1](https://img.shields.io/badge/Version-1.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.48.0](https://img.shields.io/badge/AppVersion-3.48.0-informational?style=flat-square)
 
 Open source LLM engineering platform - LLM observability, metrics, evaluations, prompt management.
 
@@ -203,6 +203,7 @@ Open source LLM engineering platform - LLM observability, metrics, evaluations, 
 | s3.auth.rootPassword | string | `""` | Password for MinIO root user |
 | s3.auth.rootPasswordSecretKey | string | `""` | Key where the Minio root user password is being stored inside the existing secret `s3.auth.existingSecret` |
 | s3.auth.rootUser | string | `"minio"` | root username |
+| s3.auth.rootUserSecretKey | string | `""` | Key where the Minio root user is being stored inside the existing secret `s3.auth.existingSecret` |
 | s3.batchExport.accessKeyId | object | `{"secretKeyRef":{"key":"","name":""},"value":""}` | S3 accessKeyId to use for batch exports. |
 | s3.batchExport.bucket | string | `""` | S3 bucket to use for batch exports. |
 | s3.batchExport.enabled | bool | `true` | Enable batch export. |

--- a/charts/langfuse/templates/_helpers.tpl
+++ b/charts/langfuse/templates/_helpers.tpl
@@ -348,7 +348,14 @@ Get value of a specific environment variable from additionalEnv if it exists
 {{- else }}
 {{- if .Values.s3.deploy }}
 - name: LANGFUSE_S3_EVENT_UPLOAD_ACCESS_KEY_ID
+  {{- if and .Values.s3.auth.existingSecret .Values.s3.auth.rootUserSecretKey }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.s3.auth.existingSecret }}
+      key: {{ .Values.s3.auth.rootUserSecretKey }}
+  {{- else }}
   value: {{ .Values.s3.auth.rootUser | quote }}
+  {{- end }}
 {{- end }}
 {{- end }}
 {{- with (include "langfuse.getS3ValueOrSecret" (dict "key" "secretAccessKey" "bucket" "eventUpload" "values" .Values.s3) ) }}
@@ -357,7 +364,14 @@ Get value of a specific environment variable from additionalEnv if it exists
 {{- else }}
 {{- if .Values.s3.deploy }}
 - name: LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY
+  {{- if and .Values.s3.auth.existingSecret .Values.s3.auth.rootPasswordSecretKey }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.s3.auth.existingSecret }}
+      key: {{ .Values.s3.auth.rootPasswordSecretKey }}
+  {{- else }}
   value: {{ .Values.s3.auth.rootPassword | quote }}
+  {{- end }}
 {{- end }}
 {{- end }}
 {{- if or (hasKey .Values.s3.eventUpload "forcePathStyle") (hasKey .Values.s3 "forcePathStyle") }}
@@ -391,7 +405,14 @@ Get value of a specific environment variable from additionalEnv if it exists
 {{- else }}
 {{- if .Values.s3.deploy }}
 - name: LANGFUSE_S3_BATCH_EXPORT_ACCESS_KEY_ID
+  {{- if and .Values.s3.auth.existingSecret .Values.s3.auth.rootUserSecretKey }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.s3.auth.existingSecret }}
+      key: {{ .Values.s3.auth.rootUserSecretKey }}
+  {{- else }}
   value: {{ .Values.s3.auth.rootUser | quote }}
+  {{- end }}
 {{- end }}
 {{- end }}
 {{- with (include "langfuse.getS3ValueOrSecret" (dict "key" "secretAccessKey" "bucket" "batchExport" "values" .Values.s3) ) }}
@@ -400,7 +421,14 @@ Get value of a specific environment variable from additionalEnv if it exists
 {{- else }}
 {{- if .Values.s3.deploy }}
 - name: LANGFUSE_S3_BATCH_EXPORT_SECRET_ACCESS_KEY
+  {{- if and .Values.s3.auth.existingSecret .Values.s3.auth.rootPasswordSecretKey }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.s3.auth.existingSecret }}
+      key: {{ .Values.s3.auth.rootPasswordSecretKey }}
+  {{- else }}
   value: {{ .Values.s3.auth.rootPassword | quote }}
+  {{- end }}
 {{- end }}
 {{- end }}
 {{- if or (hasKey .Values.s3.batchExport "forcePathStyle") (hasKey .Values.s3 "forcePathStyle") }}
@@ -432,7 +460,14 @@ Get value of a specific environment variable from additionalEnv if it exists
 {{- else }}
 {{- if .Values.s3.deploy }}
 - name: LANGFUSE_S3_MEDIA_UPLOAD_ACCESS_KEY_ID
+  {{- if and .Values.s3.auth.existingSecret .Values.s3.auth.rootUserSecretKey }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.s3.auth.existingSecret }}
+      key: {{ .Values.s3.auth.rootUserSecretKey }}
+  {{- else }}
   value: {{ .Values.s3.auth.rootUser | quote }}
+  {{- end }}
 {{- end }}
 {{- end }}
 {{- with (include "langfuse.getS3ValueOrSecret" (dict "key" "secretAccessKey" "bucket" "mediaUpload" "values" .Values.s3) ) }}
@@ -441,7 +476,14 @@ Get value of a specific environment variable from additionalEnv if it exists
 {{- else }}
 {{- if .Values.s3.deploy }}
 - name: LANGFUSE_S3_MEDIA_UPLOAD_SECRET_ACCESS_KEY
+  {{- if and .Values.s3.auth.existingSecret .Values.s3.auth.rootPasswordSecretKey }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.s3.auth.existingSecret }}
+      key: {{ .Values.s3.auth.rootPasswordSecretKey }}
+  {{- else }}
   value: {{ .Values.s3.auth.rootPassword | quote }}
+  {{- end }}
 {{- end }}
 {{- end }}
 {{- if or (hasKey .Values.s3.mediaUpload "forcePathStyle") (hasKey .Values.s3 "forcePathStyle") }}

--- a/charts/langfuse/values.yaml
+++ b/charts/langfuse/values.yaml
@@ -595,6 +595,8 @@ s3:
     rootPassword: ""
     # -- If you want to use an existing secret for the root user password, set the name of the secret here. (`s3.auth.rootUser` and `s3.auth.rootPassword` will be ignored and picked up from this secret).
     existingSecret: ""
+    # -- Key where the Minio root user is being stored inside the existing secret `s3.auth.existingSecret`
+    rootUserSecretKey: ""
     # -- Key where the Minio root user password is being stored inside the existing secret `s3.auth.existingSecret`
     rootPasswordSecretKey: ""
 


### PR DESCRIPTION
Fixes https://github.com/langfuse/langfuse-k8s/issues/116
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `s3.auth.rootUserSecretKey` to Helm chart for S3 authentication, updating templates and documentation accordingly.
> 
>   - **Behavior**:
>     - Adds `s3.auth.rootUserSecretKey` to `values.yaml` and `README.md` for specifying the key for MinIO root user in existing secrets.
>     - Updates `_helpers.tpl` to use `rootUserSecretKey` for `LANGFUSE_S3_*_ACCESS_KEY_ID` environment variables when `s3.auth.existingSecret` is set.
>   - **Versioning**:
>     - Bumps chart version from `1.2.0` to `1.2.1` in `Chart.yaml` and `README.md`.
>   - **Documentation**:
>     - Updates `README.md` to include `rootUserSecretKey` in the S3 configuration example.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-k8s&utm_source=github&utm_medium=referral)<sup> for a454dbd6eb7bbac8c68e9613aab481e5a8fd1ccc. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->