### PR TITLE
chore: add note on URL encoding for redis passwords

### DIFF
--- a/charts/langfuse/README.md
+++ b/charts/langfuse/README.md
@@ -188,7 +188,7 @@ Open source LLM engineering platform - LLM observability, metrics, evaluations, 
 | redis.auth.database | int | `0` |  |
 | redis.auth.existingSecret | string | `""` | If you want to use an existing secret for the redis password, set the name of the secret here. (`redis.auth.password` will be ignored and picked up from this secret). |
 | redis.auth.existingSecretPasswordKey | string | `""` | The key in the existing secret that contains the password. |
-| redis.auth.password | string | `""` | Configure the password by value or existing secret reference |
+| redis.auth.password | string | `""` | Configure the password by value or existing secret reference. Use URL-encoded passwords or avoid special characters in the password. |
 | redis.auth.username | string | `"default"` | Username to use to connect to the redis database deployed with Langfuse. In case `redis.deploy` is set to `true`, the user will be created automatically. Set to null for an empty username in the connection string. |
 | redis.deploy | bool | `true` | Enable valkey deployment (via Bitnami Helm Chart). If you want to use a Redis or Valkey server already deployed, set to false. |
 | redis.host | string | `""` | Redis host to connect to. If redis.deploy is true, this will be set automatically based on the release name. |

--- a/charts/langfuse/values.yaml
+++ b/charts/langfuse/values.yaml
@@ -412,7 +412,7 @@ redis:
   auth:
     # -- Username to use to connect to the redis database deployed with Langfuse. In case `redis.deploy` is set to `true`, the user will be created automatically. Set to null for an empty username in the connection string.
     username: "default"
-    # -- Configure the password by value or existing secret reference
+    # -- Configure the password by value or existing secret reference. Use URL-encoded passwords or avoid special characters in the password.
     password: ""
     # -- If you want to use an existing secret for the redis password, set the name of the secret here. (`redis.auth.password` will be ignored and picked up from this secret).
     existingSecret: ""


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add note on URL encoding for Redis passwords in Helm chart documentation and configuration files.
> 
>   - **Documentation**:
>     - Update `README.md` to include a note on using URL-encoded passwords or avoiding special characters for `redis.auth.password`.
>   - **Configuration**:
>     - Add similar note in `values.yaml` for `redis.auth.password` configuration.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-k8s&utm_source=github&utm_medium=referral)<sup> for f77c853c76724a0dfa33204c1e19c93d25c816c8. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->