### PR TITLE
docs: added langfuse artifact hub badge to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 # langfuse-k8s
 
+[![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/langfuse-k8s)](https://artifacthub.io/packages/search?repo=langfuse-k8s)
+
 This is a community-maintained repository that contains resources for deploying Langfuse on Kubernetes.
 
 ## Helm Chart


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add Artifact Hub badge to `README.md` for Langfuse packages visibility.
> 
>   - **Documentation**:
>     - Added Artifact Hub badge to `README.md` to link to Langfuse packages on Artifact Hub.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-k8s&utm_source=github&utm_medium=referral)<sup> for 1944c043bec78a70d22b2ceacd37af1825980569. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->