### PR TITLE
fix: add ssl config for self-hosted clickhouse

### DIFF
--- a/charts/langfuse/Chart.yaml
+++ b/charts/langfuse/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: langfuse
-version: 1.2.1
+version: 1.2.2
 description: Open source LLM engineering platform - LLM observability, metrics, evaluations, prompt management.
 type: application
 keywords:
@@ -40,4 +40,4 @@ maintainers:
     email: contact@langfuse.com
     url: https://langfuse.com/
 icon: https://langfuse.com/langfuse_logo.png
-appVersion: "3.48.0"
+appVersion: "3.48.1"

--- a/charts/langfuse/README.md
+++ b/charts/langfuse/README.md
@@ -1,6 +1,6 @@
 # langfuse
 
-![Version: 1.2.1](https://img.shields.io/badge/Version-1.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.48.0](https://img.shields.io/badge/AppVersion-3.48.0-informational?style=flat-square)
+![Version: 1.2.2](https://img.shields.io/badge/Version-1.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.48.1](https://img.shields.io/badge/AppVersion-3.48.1-informational?style=flat-square)
 
 Open source LLM engineering platform - LLM observability, metrics, evaluations, prompt management.
 

--- a/charts/langfuse/templates/_helpers.tpl
+++ b/charts/langfuse/templates/_helpers.tpl
@@ -283,6 +283,8 @@ Get value of a specific environment variable from additionalEnv if it exists
 {{- define "langfuse.clickhouseEnv" -}}
 - name: CLICKHOUSE_MIGRATION_URL
   value: "clickhouse://{{ include "langfuse.clickhouse.hostname" . }}:{{ .Values.clickhouse.nativePort }}"
+- name: CLICKHOUSE_MIGRATION_SSL
+  value: {{ .Values.clickhouse.migration.ssl | quote }}
 - name: CLICKHOUSE_URL
   value: "http://{{ include "langfuse.clickhouse.hostname" . }}:{{ .Values.clickhouse.httpPort }}"
 - name: CLICKHOUSE_USER


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add SSL configuration for ClickHouse migrations and update chart and app versions.
> 
>   - **Behavior**:
>     - Add `CLICKHOUSE_MIGRATION_SSL` environment variable in `langfuse.clickhouseEnv` in `_helpers.tpl` to support SSL configuration for ClickHouse migrations.
>   - **Versioning**:
>     - Update chart version to `1.2.2` and app version to `3.48.1` in `Chart.yaml` and `README.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-k8s&utm_source=github&utm_medium=referral)<sup> for e4e6525dae97c8c65d61c35c96c14f973dc5f6bb. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->