### PR TITLE
chore: handle clickhouse protocol

### DIFF
--- a/charts/langfuse/Chart.yaml
+++ b/charts/langfuse/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: langfuse
-version: 1.2.2
+version: 1.2.3
 description: Open source LLM engineering platform - LLM observability, metrics, evaluations, prompt management.
 type: application
 keywords:

--- a/charts/langfuse/README.md
+++ b/charts/langfuse/README.md
@@ -1,6 +1,6 @@
 # langfuse
 
-![Version: 1.2.2](https://img.shields.io/badge/Version-1.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.48.1](https://img.shields.io/badge/AppVersion-3.48.1-informational?style=flat-square)
+![Version: 1.2.3](https://img.shields.io/badge/Version-1.2.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.48.1](https://img.shields.io/badge/AppVersion-3.48.1-informational?style=flat-square)
 
 Open source LLM engineering platform - LLM observability, metrics, evaluations, prompt management.
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Handle ClickHouse protocol in Helm chart by stripping protocol from hostname and determining protocol type.
> 
>   - **Behavior**:
>     - Update `langfuse.clickhouse.hostname` in `_helpers.tpl` to strip protocol from ClickHouse host.
>     - Add `langfuse.clickhouse.protocol` in `_helpers.tpl` to determine ClickHouse protocol (http or https).
>     - Update `CLICKHOUSE_URL` in `langfuse.clickhouseEnv` to use the new protocol helper.
>   - **Versioning**:
>     - Bump chart version to 1.2.3 in `Chart.yaml` and `README.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-k8s&utm_source=github&utm_medium=referral)<sup> for 22b8ad2d7af95b0cfc7fb95e5f3feed424403858. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->