### PR TITLE
fix: do not set DATABASE_URL twice if configured via additionalEnv

### DIFF
--- a/charts/langfuse/Chart.yaml
+++ b/charts/langfuse/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: langfuse
-version: 1.2.3
+version: 1.2.4
 description: Open source LLM engineering platform - LLM observability, metrics, evaluations, prompt management.
 type: application
 keywords:
@@ -40,4 +40,4 @@ maintainers:
     email: contact@langfuse.com
     url: https://langfuse.com/
 icon: https://langfuse.com/langfuse_logo.png
-appVersion: "3.48.1"
+appVersion: "3.51.2"

--- a/charts/langfuse/README.md
+++ b/charts/langfuse/README.md
@@ -1,6 +1,6 @@
 # langfuse
 
-![Version: 1.2.3](https://img.shields.io/badge/Version-1.2.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.48.1](https://img.shields.io/badge/AppVersion-3.48.1-informational?style=flat-square)
+![Version: 1.2.4](https://img.shields.io/badge/Version-1.2.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.51.2](https://img.shields.io/badge/AppVersion-3.51.2-informational?style=flat-square)
 
 Open source LLM engineering platform - LLM observability, metrics, evaluations, prompt management.
 

--- a/charts/langfuse/templates/_helpers.tpl
+++ b/charts/langfuse/templates/_helpers.tpl
@@ -162,8 +162,9 @@ Get value of a specific environment variable from additionalEnv if it exists
 */}}
 {{- define "langfuse.databaseEnv" -}}
 {{- with (include "langfuse.getEnvVar" (dict "env" .Values.langfuse.additionalEnv "name" "DATABASE_URL")) -}}
-- name: DATABASE_URL
-  value: {{ . | quote }}
+{{/*
+    If DATABASE_URL is set, we do nothing in databaseEnv.
+*/}}
 {{- else -}}
 - name: DATABASE_HOST
   value: {{ include "langfuse.postgresql.hostname" . | quote }}


### PR DESCRIPTION
Fixes https://github.com/langfuse/langfuse-k8s/issues/114 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Prevents setting `DATABASE_URL` twice if configured via `additionalEnv` and updates chart and app versions.
> 
>   - **Behavior**:
>     - Prevents setting `DATABASE_URL` twice if configured via `additionalEnv` in `langfuse.databaseEnv` in `_helpers.tpl`.
>   - **Version Updates**:
>     - Bumps chart version to `1.2.4` and app version to `3.51.2` in `Chart.yaml` and `README.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-k8s&utm_source=github&utm_medium=referral)<sup> for 620c8c92c23dfe4980775441f8e7d7d30065732b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->