### PR TITLE
Add namespace to templates

### DIFF
--- a/charts/langfuse/templates/ingress.yaml
+++ b/charts/langfuse/templates/ingress.yaml
@@ -14,6 +14,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ include "langfuse.fullname" . }}
+  namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "langfuse.labels" . | nindent 4 }}
     {{- with .Values.langfuse.ingress.additionalLabels }}

--- a/charts/langfuse/templates/nextauth-secret.yaml
+++ b/charts/langfuse/templates/nextauth-secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "langfuse.fullname" . }}-nextauth
+  namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "langfuse.labels" . | nindent 4 }}
 data:

--- a/charts/langfuse/templates/postgresql-secret.yaml
+++ b/charts/langfuse/templates/postgresql-secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "langfuse.fullname" . }}-postgresql
+  namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "langfuse.labels" . | nindent 4 }}
 type: Opaque

--- a/charts/langfuse/templates/serviceaccount.yaml
+++ b/charts/langfuse/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "langfuse.serviceAccountName" . }}
+  namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "langfuse.labels" . | nindent 4 }}
   {{- with .Values.langfuse.serviceAccount.annotations }}

--- a/charts/langfuse/templates/web/deployment.yaml
+++ b/charts/langfuse/templates/web/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "langfuse.fullname" . }}-web
+  namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "langfuse.labels" . | nindent 4 }}
   {{- with (coalesce .Values.langfuse.web.deployment.annotations .Values.langfuse.deployment.annotations) }}

--- a/charts/langfuse/templates/web/hpa.yaml
+++ b/charts/langfuse/templates/web/hpa.yaml
@@ -3,6 +3,7 @@ apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "langfuse.fullname" . }}-web
+  namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "langfuse.labels" . | nindent 4 }}
 spec:

--- a/charts/langfuse/templates/web/scaled-object.yaml
+++ b/charts/langfuse/templates/web/scaled-object.yaml
@@ -3,6 +3,7 @@ apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
   name: {{ include "langfuse.fullname" . }}-web
+  namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "langfuse.labels" . | nindent 4 }}
 spec:

--- a/charts/langfuse/templates/web/service.yaml
+++ b/charts/langfuse/templates/web/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "langfuse.fullname" . }}-web
+  namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "langfuse.labels" . | nindent 4 }}
     {{- with .Values.langfuse.web.service.additionalLabels }}

--- a/charts/langfuse/templates/web/vpa.yaml
+++ b/charts/langfuse/templates/web/vpa.yaml
@@ -3,6 +3,7 @@ apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
   name: {{ include "langfuse.fullname" . }}-web
+  namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "langfuse.labels" . | nindent 4 }}
 spec:

--- a/charts/langfuse/templates/worker/deployment.yaml
+++ b/charts/langfuse/templates/worker/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "langfuse.fullname" . }}-worker
+  namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "langfuse.labels" . | nindent 4 }}
   {{- with (coalesce .Values.langfuse.worker.deployment.annotations .Values.langfuse.deployment.annotations) }}

--- a/charts/langfuse/templates/worker/hpa.yaml
+++ b/charts/langfuse/templates/worker/hpa.yaml
@@ -3,6 +3,7 @@ apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "langfuse.fullname" . }}-worker
+  namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "langfuse.labels" . | nindent 4 }}
 spec:

--- a/charts/langfuse/templates/worker/scaled-object.yaml
+++ b/charts/langfuse/templates/worker/scaled-object.yaml
@@ -3,6 +3,7 @@ apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
   name: {{ include "langfuse.fullname" . }}-worker
+  namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "langfuse.labels" . | nindent 4 }}
 spec:

--- a/charts/langfuse/templates/worker/vpa.yaml
+++ b/charts/langfuse/templates/worker/vpa.yaml
@@ -3,6 +3,7 @@ apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
   name: {{ include "langfuse.fullname" . }}-worker
+  namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "langfuse.labels" . | nindent 4 }}
 spec:


### PR DESCRIPTION
Thanks for this chart! I was running it, and noticed that the namespace I was specifying with `-n foo` was only taking effect in the subcharts. Adding it to the other templates here to apply everywhere.

--- 

## Testing

### Before
 
```
cd charts/langfuse
helm dependency build
```

The current behavior should add the namespace 39 times:

```
helm template -n foo -f values.lint.yaml . | grep namespace | wc -l
```

### After

Then after checking out this branch, the same command should show 44:

```
helm template -n foo -f values.lint.yaml . | grep namespace | wc -l
```