### PR TITLE
Fix inconsistency between postgress password key for langfuse and postgress.

### DIFF
--- a/charts/langfuse/templates/_helpers.tpl
+++ b/charts/langfuse/templates/_helpers.tpl
@@ -181,7 +181,7 @@ Get value of a specific environment variable from additionalEnv if it exists
   valueFrom:
     secretKeyRef:
       name: {{ .Values.postgresql.auth.existingSecret }}
-      key: {{ required "postgresql.auth.secretKeys.userPasswordKey is required when using an existing secret" .Values.postgresql.auth.secretKeys.userPasswordKey }}
+      key: {{ required "postgresql.auth.username is required when using an existing secret" .Values.postgresql.auth.username }}-{{ required "postgresql.auth.secretKeys.userPasswordKey is required when using an existing secret" .Values.postgresql.auth.secretKeys.userPasswordKey }}
 {{- else }}
   value: {{ required "Using an existing secret or postgresql.auth.password is required" .Values.postgresql.auth.password | quote }}
 {{- end }}


### PR DESCRIPTION
Fixes #141

# Fix
Use the same naming convention for DATABASE_PASSWORD used in `langfuse-web` and `langfuse-worker` pods as subcharts of postgress uses.

## Before
The subchart of postgress modifies the secret key, by pre-pending the user name to the key. By default `postgress-`.
This results in a mismatch with the environment variables used in the `langfuse-web` and `langfuse-worker` pods.

## After
Environment variable `DATABASE_PASSWORD` now also prepends db username: `<username>-<userPasswordKey>`.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `DATABASE_PASSWORD` naming inconsistency by prepending db username to key in `langfuse-web` and `langfuse-worker` pods.
> 
>   - **Behavior**:
>     - Fixes inconsistency in `DATABASE_PASSWORD` environment variable naming in `langfuse-web` and `langfuse-worker` pods.
>     - Environment variable key now prepends db username: `<username>-<userPasswordKey>`.
>   - **Templates**:
>     - Updated `langfuse.getEnvVar` in `_helpers.tpl` to reflect new key format.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-k8s&utm_source=github&utm_medium=referral)<sup> for d424c4eeb50594b7da32756300406eeb29aa992c. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->