### PR TITLE
Version Mismatch - Update Chart.yaml

### DIFF
--- a/charts/langfuse/Chart.yaml
+++ b/charts/langfuse/Chart.yaml
@@ -40,4 +40,4 @@ maintainers:
     email: contact@langfuse.com
     url: https://langfuse.com/
 icon: https://langfuse.com/langfuse_logo.png
-appVersion: "3.54.1"
+appVersion: "3.55"


### PR DESCRIPTION
- Added proper version for langfuse

As there is no version called `3.54.1` available in docker:

![image](https://github.com/user-attachments/assets/cc15ccbb-53f8-4123-b5d5-999f26fb347a)


With this, most of us were facing issues `ImagePullBackOff` issues on AKS.