### PR TITLE
fix: allow external redis configuration via connection string

### DIFF
--- a/charts/langfuse/templates/validations.yaml
+++ b/charts/langfuse/templates/validations.yaml
@@ -21,8 +21,8 @@
     {{- fail "Langfuse requires valkey to be deployed with the `--maxmemory-policy noeviction` flag. Set redis.primary.extraFlags to include this flag to continue." -}}
 {{- end -}}
 
-{{- if and (not $.Values.redis.deploy) (not $.Values.redis.host) -}}
-    {{- fail "Redis host must be configured when using an external Redis instance. Set redis.host to continue." -}}
+{{- if and (not $.Values.redis.deploy) (not $.Values.redis.host) (not (include "langfuse.getEnvVar" (dict "env" $.Values.langfuse.additionalEnv "name" "REDIS_CONNECTION_STRING"))) -}}
+    {{- fail "For external Redis, either set redis.host or provide REDIS_CONNECTION_STRING via additionalEnv." -}}
 {{- end -}}
 
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Allow external Redis configuration via `REDIS_CONNECTION_STRING` in `validations.yaml`.
> 
>   - **Behavior**:
>     - Updated Redis validation in `validations.yaml` to allow external Redis configuration via `REDIS_CONNECTION_STRING` in `langfuse.additionalEnv`.
>     - If using external Redis, either `redis.host` or `REDIS_CONNECTION_STRING` must be set.
>   - **Validation**:
>     - Ensures only one of `redis.host` or `REDIS_CONNECTION_STRING` is configured to avoid conflicts.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-k8s&utm_source=github&utm_medium=referral)<sup> for 2e2f137a208fd8a53e2e090163f84ede9af2e5bf. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->