### PR TITLE
Fix S3 Upload Type Specific Endpoint Configuration

### DIFF
--- a/charts/langfuse/templates/_helpers.tpl
+++ b/charts/langfuse/templates/_helpers.tpl
@@ -366,9 +366,9 @@ Return ClickHouse protocol (http or https)
 - name: LANGFUSE_S3_EVENT_UPLOAD_REGION
   value: {{ .Values.s3.eventUpload.region | default .Values.s3.region | quote }}
 {{- end }}
-{{- with (include "langfuse.s3.endpoint" .) }}
+{{- if or .Values.s3.eventUpload.endpoint .Values.s3.endpoint }}
 - name: LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT
-  value: {{ . | quote }}
+  value: {{ .Values.s3.eventUpload.endpoint | default .Values.s3.endpoint | quote }}
 {{- end }}
 {{- with (include "langfuse.getS3ValueOrSecret" (dict "key" "accessKeyId" "bucket" "eventUpload" "values" .Values.s3) ) }}
 - name: LANGFUSE_S3_EVENT_UPLOAD_ACCESS_KEY_ID
@@ -423,9 +423,9 @@ Return ClickHouse protocol (http or https)
 - name: LANGFUSE_S3_BATCH_EXPORT_REGION
   value: {{ .Values.s3.batchExport.region | default .Values.s3.region | quote }}
 {{- end }}
-{{- with (include "langfuse.s3.endpoint" .) }}
+{{- if or .Values.s3.batchExport.endpoint .Values.s3.endpoint }}
 - name: LANGFUSE_S3_BATCH_EXPORT_ENDPOINT
-  value: {{ . | quote }}
+  value: {{ .Values.s3.batchExport.endpoint | default .Values.s3.endpoint | quote }}
 {{- end }}
 {{- with (include "langfuse.getS3ValueOrSecret" (dict "key" "accessKeyId" "bucket" "batchExport" "values" .Values.s3) ) }}
 - name: LANGFUSE_S3_BATCH_EXPORT_ACCESS_KEY_ID
@@ -478,9 +478,9 @@ Return ClickHouse protocol (http or https)
 - name: LANGFUSE_S3_MEDIA_UPLOAD_REGION
   value: {{ .Values.s3.mediaUpload.region | default .Values.s3.region | quote }}
 {{- end }}
-{{- with (include "langfuse.s3.endpoint" .) }}
+{{- if or .Values.s3.mediaUpload.endpoint .Values.s3.endpoint }}
 - name: LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT
-  value: {{ . | quote }}
+  value: {{ .Values.s3.mediaUpload.endpoint | default .Values.s3.endpoint | quote }}
 {{- end }}
 {{- with (include "langfuse.getS3ValueOrSecret" (dict "key" "accessKeyId" "bucket" "mediaUpload" "values" .Values.s3) ) }}
 - name: LANGFUSE_S3_MEDIA_UPLOAD_ACCESS_KEY_ID


### PR DESCRIPTION
On chart version 1.2.7 (and head), type-specific endpoints set in values (e.g. `s3.batchExport.endpoint`) did not work correctly and all endpoints were set to `s3.eventUpload.endpoint` instead. This pull requests fixes the behavior and S3 endpoints are set according to the most granular setting as described in documentation.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes S3 endpoint configuration in Helm chart to correctly use type-specific endpoints instead of defaulting to a single endpoint.
> 
>   - **Behavior**:
>     - Fixes S3 endpoint configuration in `_helpers.tpl` to correctly use type-specific endpoints (`s3.batchExport.endpoint`, `s3.mediaUpload.endpoint`, etc.) instead of defaulting to `s3.eventUpload.endpoint`.
>     - Ensures that the most specific endpoint setting is used, falling back to general `s3.endpoint` if type-specific is not set.
>   - **Files**:
>     - Updates in `_helpers.tpl` to handle endpoint logic for `LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT`, `LANGFUSE_S3_BATCH_EXPORT_ENDPOINT`, and `LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-k8s&utm_source=github&utm_medium=referral)<sup> for cb21fbc690404c908e33a5d643ed9b380f572230. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->