### PR TITLE
docs: add sizing guide to helm readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,60 @@ helm upgrade langfuse langfuse/langfuse
 Please validate whether the helm sub-charts in the Chart.yaml were updated between versions.
 If yes, follow the guide for the respective sub-chart to upgrade it.
 
+### Sizing
+
+By default, the chart will run with the minimum resources to provide a stable experience.
+For production environments, we recommend to adjust the following parameters in the values.yaml.
+See [Langfuse documentation](http://localhost:3333/self-hosting/scaling) for our full sizing guide.
+
+```yaml
+langfuse:
+  resources:
+    limits:
+      cpu: "2"
+      memory: "4Gi"
+    requests:
+      cpu: "2"
+      memory: "4Gi"
+
+clickhouse:
+  resources:
+    limits:
+      cpu: "2"
+      memory: "8Gi"
+    requests:
+      cpu: "2"
+      memory: "8Gi"
+      
+  keeper:
+    resources:
+      limits:
+        cpu: "2"
+        memory: "4Gi"
+      requests:
+        cpu: "2"
+        memory: "4Gi"
+
+redis:
+  primary:
+    resources:
+      limits:
+        cpu: "1"
+        memory: "1.5Gi"
+      requests:
+        cpu: "1"
+        memory: "1.5Gi"
+
+s3:
+  resources:
+    limits:
+      cpu: "2"
+      memory: "4Gi"
+    requests:
+      cpu: "2"
+      memory: "4Gi"
+```
+
 ### Configuration
 
 The required configuration options to set are:

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ If yes, follow the guide for the respective sub-chart to upgrade it.
 
 By default, the chart will run with the minimum resources to provide a stable experience.
 For production environments, we recommend to adjust the following parameters in the values.yaml.
-See [Langfuse documentation](http://localhost:3333/self-hosting/scaling) for our full sizing guide.
+See [Langfuse documentation](https://langfuse.com/self-hosting/scaling) for our full sizing guide.
 
 ```yaml
 langfuse:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a sizing guide to `README.md` for Helm chart deployments, recommending resource adjustments for production environments.
> 
>   - **Documentation**:
>     - Adds a "Sizing" section to `README.md` for Helm chart deployments.
>     - Recommends resource adjustments for production environments in `values.yaml`.
>     - Provides example YAML configuration for `langfuse`, `clickhouse`, `redis`, and `s3` resources.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-k8s&utm_source=github&utm_medium=referral)<sup> for 3aafb537782e16ad324dc26d4ee4cab297791d37. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->