### PR TITLE
feat: add more configs to values 

### DIFF
--- a/charts/langfuse/README.md
+++ b/charts/langfuse/README.md
@@ -50,6 +50,7 @@ Open source LLM engineering platform - LLM observability, metrics, evaluations, 
 | fullnameOverride | string | `""` | Override the full name of the deployed resources, defaults to a combination of the release name and the name for the selector labels |
 | langfuse.additionalEnv | list | `[]` | List of additional environment variables to be added to all langfuse deployments. See [documentation](https://langfuse.com/docs/deployment/self-host#configuring-environment-variables) for details. |
 | langfuse.affinity | object | `{}` | Affinity for all langfuse deployments |
+| langfuse.allowedOrganizationCreators | list | `[]` | EE: Langfuse allowed organization creators. See [documentation](https://langfuse.com/self-hosting/organization-creators) |
 | langfuse.deployment.annotations | object | `{}` | Annotations for all langfuse deployments |
 | langfuse.deployment.strategy | object | `{}` | Deployment strategy for all langfuse deployments (can be overridden by individual deployments) |
 | langfuse.encryptionKey | object | `{"secretKeyRef":{"key":"","name":""},"value":""}` | Used to encrypt sensitive data. Must be 256 bits (64 string characters in hex format). Generate via `openssl rand -hex 32`. |
@@ -88,6 +89,8 @@ Open source LLM engineering platform - LLM observability, metrics, evaluations, 
 | langfuse.serviceAccount.annotations | object | `{}` | Annotations for the service account |
 | langfuse.serviceAccount.create | bool | `true` | Whether to create a service account for all langfuse deployments |
 | langfuse.serviceAccount.name | string | `""` | Override the name of the service account to use, discovered automatically if not set |
+| langfuse.smtp.connectionUrl | string | `""` | SMTP connection URL. See [documentation](https://langfuse.com/self-hosting/transactional-emails) |
+| langfuse.smtp.fromAddress | string | `""` | From address for emails. Required if connectionUrl is set. |
 | langfuse.tolerations | list | `[]` | Tolerations for all langfuse deployments |
 | langfuse.web.deployment.annotations | object | `{}` | Annotations for the web deployment |
 | langfuse.web.deployment.strategy | object | `{}` | Deployment strategy for the web deployment. Overrides the global deployment strategy |

--- a/charts/langfuse/templates/_helpers.tpl
+++ b/charts/langfuse/templates/_helpers.tpl
@@ -243,6 +243,12 @@ Get value of a specific environment variable from additionalEnv if it exists
   value: {{ required "langfuse.smtp.fromAddress has to be set if langfuse.smtp.connectionUrl is configured" .Values.langfuse.smtp.fromAddress | quote }}
 {{- end }}
 {{- end }}
+{{- if hasKey .Values.langfuse "allowedOrganizationCreators" }}
+{{- if .Values.langfuse.allowedOrganizationCreators }}
+- name: LANGFUSE_ALLOWED_ORGANIZATION_CREATORS
+  value: {{ join "," .Values.langfuse.allowedOrganizationCreators | quote }}
+{{- end }}
+{{- end }}
 {{- end -}}
 
 {{/*

--- a/charts/langfuse/templates/_helpers.tpl
+++ b/charts/langfuse/templates/_helpers.tpl
@@ -235,6 +235,14 @@ Get value of a specific environment variable from additionalEnv if it exists
   value: {{ .Values.langfuse.features.signUpDisabled | quote }}
 - name: ENABLE_EXPERIMENTAL_FEATURES
   value: {{ .Values.langfuse.features.experimentalFeaturesEnabled | quote }}
+{{- if hasKey .Values.langfuse "smtp" }}
+{{- if .Values.langfuse.smtp.connectionUrl }}
+- name: SMTP_CONNECTION_URL
+  value: {{ .Values.langfuse.smtp.connectionUrl | quote }}
+- name: EMAIL_FROM_ADDRESS
+  value: {{ required "langfuse.smtp.fromAddress has to be set if langfuse.smtp.connectionUrl is configured" .Values.langfuse.smtp.fromAddress | quote }}
+{{- end }}
+{{- end }}
 {{- end -}}
 
 {{/*

--- a/charts/langfuse/templates/_helpers.tpl
+++ b/charts/langfuse/templates/_helpers.tpl
@@ -260,6 +260,18 @@ Get value of a specific environment variable from additionalEnv if it exists
   value: {{ .Values.langfuse.nextauth.url | quote }}
 - name: NEXTAUTH_SECRET
   {{- include "langfuse.getRequiredValueOrSecret" (dict "key" "langfuse.nextauth.secret" "value" .Values.langfuse.nextauth.secret) | nindent 2 }}
+{{- if and (hasKey .Values.langfuse "auth") (hasKey .Values.langfuse.auth "disableUsernamePassword") }}
+- name: AUTH_DISABLE_USERNAME_PASSWORD
+  value: {{ .Values.langfuse.auth.disableUsernamePassword | quote }}
+{{- end }}
+{{- if and (hasKey .Values.langfuse "auth") (hasKey .Values.langfuse.auth "providers") }}
+{{- range $providerName, $provider := .Values.langfuse.auth.providers }}
+{{- range $optionKey, $optionVal := $provider }}
+- name: AUTH_{{ $providerName | snakecase | upper }}_{{ $optionKey | snakecase | upper }}
+  value: {{ $optionVal | quote }}
+{{- end }}
+{{- end }}
+{{- end }}
 {{- end -}}
 
 {{/*

--- a/charts/langfuse/templates/validations.yaml
+++ b/charts/langfuse/templates/validations.yaml
@@ -164,6 +164,14 @@
     {{- fail "Only one of additionalEnv or the new structure can be configured. Set either langfuse.features.experimentalFeaturesEnabled or langfuse.additionalEnv[name: ENABLE_EXPERIMENTAL_FEATURES] to continue." -}}
 {{- end -}}
 
+# Validate that only one of additionalEnv or new structure is configured for SMTP config
+{{- if and $.Values.langfuse.smtp.connectionUrl (include "langfuse.getEnvVar" (dict "env" $.Values.langfuse.additionalEnv "name" "SMTP_CONNECTION_URL")) -}}
+    {{- fail "Only one of additionalEnv or the new structure can be configured. Set either langfuse.smtp.connectionUrl or langfuse.additionalEnv[name: SMTP_CONNECTION_URL] to continue." -}}
+{{- end -}}
+{{- if and $.Values.langfuse.smtp.fromAddress (include "langfuse.getEnvVar" (dict "env" $.Values.langfuse.additionalEnv "name" "EMAIL_FROM_ADDRESS")) -}}
+    {{- fail "Only one of additionalEnv or the new structure can be configured. Set either langfuse.smtp.fromAddress or langfuse.additionalEnv[name: EMAIL_FROM_ADDRESS] to continue." -}}
+{{- end -}}
+
 # Validate that only one of additionalEnv or new structure is configured for Authentication and Security
 {{- if and $.Values.langfuse.salt (include "langfuse.getEnvVar" (dict "env" $.Values.langfuse.additionalEnv "name" "SALT")) -}}
     {{- fail "Only one of additionalEnv or the new structure can be configured. Set either langfuse.salt or langfuse.additionalEnv[name: SALT] to continue." -}}

--- a/charts/langfuse/templates/validations.yaml
+++ b/charts/langfuse/templates/validations.yaml
@@ -6,6 +6,14 @@
     {{- fail "langfuse.logging.format must be one of: text, json" -}}
 {{- end -}}
 
+# Validate auth providers settings
+{{- if and (hasKey .Values.langfuse "auth") (hasKey .Values.langfuse.auth "providers") }}
+{{- range $providerName, $provider := .Values.langfuse.auth.providers -}}
+{{- if not (has ($providerName | snakecase | upper) (list "AUTH0" "COGNITO" "AZURE_AD" "GITHUB" "GITHUB_ENTERPRISE" "GITLAB" "GOOGLE" "KEYCLOAK" "OKTA" "WORKOS" "CUSTOM")) -}}
+  {{- fail (printf "langfuse.auth: invalid auth provider %s" $providerName)}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
 
 # Validate ClickHouse settings
 {{- if ne ($.Values.clickhouse.shards | int) 1 -}}

--- a/charts/langfuse/templates/validations.yaml
+++ b/charts/langfuse/templates/validations.yaml
@@ -172,6 +172,11 @@
     {{- fail "Only one of additionalEnv or the new structure can be configured. Set either langfuse.smtp.fromAddress or langfuse.additionalEnv[name: EMAIL_FROM_ADDRESS] to continue." -}}
 {{- end -}}
 
+# Validate that only one of additionalEnv or new structure is configured for Allowed Organization Creators
+{{- if and $.Values.langfuse.allowedOrganizationCreators (include "langfuse.getEnvVar" (dict "env" $.Values.langfuse.additionalEnv "name" "LANGFUSE_ALLOWED_ORGANIZATION_CREATORS")) -}}
+    {{- fail "Only one of additionalEnv or the new structure can be configured. Set either langfuse.allowedOrganizationCreators or langfuse.additionalEnv[name: LANGFUSE_ALLOWED_ORGANIZATION_CREATORS] to continue." -}}
+{{- end -}}
+
 # Validate that only one of additionalEnv or new structure is configured for Authentication and Security
 {{- if and $.Values.langfuse.salt (include "langfuse.getEnvVar" (dict "env" $.Values.langfuse.additionalEnv "name" "SALT")) -}}
     {{- fail "Only one of additionalEnv or the new structure can be configured. Set either langfuse.salt or langfuse.additionalEnv[name: SALT] to continue." -}}

--- a/charts/langfuse/values.yaml
+++ b/charts/langfuse/values.yaml
@@ -73,9 +73,8 @@ langfuse:
     # -- Override the name of the service account to use, discovered automatically if not set
     name: ""
 
-  # -- Langfuse SMTP options. See [documentation](https://langfuse.com/self-hosting/transactional-emails)
   smtp:
-    # -- SMTP connection URL
+    # -- SMTP connection URL. See [documentation](https://langfuse.com/self-hosting/transactional-emails)
     connectionUrl: ""
     # -- From address for emails. Required if connectionUrl is set.
     fromAddress: ""

--- a/charts/langfuse/values.yaml
+++ b/charts/langfuse/values.yaml
@@ -32,6 +32,20 @@ langfuse:
   # -- EE: Langfuse allowed organization creators. See [documentation](https://langfuse.com/self-hosting/organization-creators)
   allowedOrganizationCreators: []
 
+  # -- Authentication and SSO settings:
+  # -- If you want to disable username/password login, set auth.disableUsernamePassword to true.
+  # -- Refer to [documentation](https://langfuse.com/self-hosting/authentication-and-sso) for available keys for each provider.
+  # -- For each provider, add it to auth.providers, and add respective configuration options under it.
+  # -- For options, use the last part (after provider name) of the respective environment variable's name, in camelCase.
+  # -- For example, to use Azure AD as your SSO provider, use the following lines:
+  # auth:
+  #   disableUsernamePassword: true
+  #   providers:
+  #     azureAd:
+  #       clientId: "<YOUR CLIENT ID>"
+  #       clientSecret: "<YOUR CLIENT SECRET>"
+  #       tenantId: "<YOUR TENANT ID>"
+
   # -- Used to encrypt sensitive data. Must be 256 bits (64 string characters in hex format). Generate via `openssl rand -hex 32`.
   encryptionKey:
     value: ""

--- a/charts/langfuse/values.yaml
+++ b/charts/langfuse/values.yaml
@@ -29,6 +29,9 @@ langfuse:
       name: ""
       key: ""
 
+  # -- EE: Langfuse allowed organization creators. See [documentation](https://langfuse.com/self-hosting/organization-creators)
+  allowedOrganizationCreators: []
+
   # -- Used to encrypt sensitive data. Must be 256 bits (64 string characters in hex format). Generate via `openssl rand -hex 32`.
   encryptionKey:
     value: ""

--- a/charts/langfuse/values.yaml
+++ b/charts/langfuse/values.yaml
@@ -56,6 +56,13 @@ langfuse:
     # -- Override the name of the service account to use, discovered automatically if not set
     name: ""
 
+  # -- Langfuse SMTP options. See [documentation](https://langfuse.com/self-hosting/transactional-emails)
+  smtp:
+    # -- SMTP connection URL
+    connectionUrl: ""
+    # -- From address for emails. Required if connectionUrl is set.
+    fromAddress: ""
+
   ingress:
     # -- Set to `true` to enable the ingress resource
     enabled: false


### PR DESCRIPTION
This pull requests enables specifying several configuration options directly in helm values instead of via env variables.
The new keys are:

- `langfuse.smtp.connectionUrl` for `SMTP_CONNECTION_URL`
- `langfuse.smtp.fromAddress` for `EMAIL_FROM_ADDRESS`
- `langfuse.allowedOrganizationCreators` for `LANGFUSE_ALLOWED_ORGANIZATION_CREATORS`
- `langfuse.auth.disableUsernamePassword` for `AUTH_DISABLE_USERNAME_PASSWORD`
- `langfuse.auth.providers.[provider].*` for `AUTH_<provider>_<*>`

The pull requests also includes respective validations and documentation in the `values.yml` file.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add new Helm chart configurations for SMTP, organization creators, and authentication, with validations to ensure single configuration method usage.
> 
>   - **Configuration**:
>     - Add `langfuse.smtp.connectionUrl` and `langfuse.smtp.fromAddress` for SMTP settings.
>     - Add `langfuse.allowedOrganizationCreators` for organization creator settings.
>     - Add `langfuse.auth.disableUsernamePassword` and `langfuse.auth.providers.[provider].*` for authentication settings.
>   - **Validation**:
>     - Ensure only one configuration method (new structure or `additionalEnv`) is used for SMTP, organization creators, and authentication in `validations.yaml`.
>   - **Documentation**:
>     - Update `values.yaml` with new configuration options and descriptions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-k8s&utm_source=github&utm_medium=referral)<sup> for b9039566045107288c7e36690d7268118591bf25. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->