### PR TITLE
Add langfuse.web.service.externalPort variable

### DIFF
--- a/charts/langfuse/README.md
+++ b/charts/langfuse/README.md
@@ -127,6 +127,7 @@ Open source LLM engineering platform - LLM observability, metrics, evaluations, 
 | langfuse.web.resources | object | `{}` | Resources for the langfuse web pods. Defaults to the global resources |
 | langfuse.web.service.additionalLabels | object | `{}` | Additional labels for the langfuse web application service |
 | langfuse.web.service.annotations | object | `{}` | Annotations for the langfuse web application service |
+| langfuse.web.service.externalPort | string | `nil` | The external port that will be exposed by the service. Falls back to `port` if not set. |
 | langfuse.web.service.nodePort | string | `nil` | The node port to use for the langfuse web application |
 | langfuse.web.service.port | int | `3000` | The port to use for the langfuse web application |
 | langfuse.web.service.type | string | `"ClusterIP"` | The type of service to use for the langfuse web application |

--- a/charts/langfuse/templates/web/service.yaml
+++ b/charts/langfuse/templates/web/service.yaml
@@ -14,7 +14,7 @@ metadata:
 spec:
   type: {{ .Values.langfuse.web.service.type }}
   ports:
-    - port: {{ .Values.langfuse.web.service.port }}
+    - port: {{ .Values.langfuse.web.service.externalPort }}
       targetPort: http
       protocol: TCP
       name: http

--- a/charts/langfuse/templates/web/service.yaml
+++ b/charts/langfuse/templates/web/service.yaml
@@ -14,7 +14,7 @@ metadata:
 spec:
   type: {{ .Values.langfuse.web.service.type }}
   ports:
-    - port: {{ .Values.langfuse.web.service.externalPort }}
+    - port: {{ .Values.langfuse.web.service.externalPort | default .Values.langfuse.web.service.port }}
       targetPort: http
       protocol: TCP
       name: http

--- a/charts/langfuse/values.yaml
+++ b/charts/langfuse/values.yaml
@@ -152,6 +152,8 @@ langfuse:
       type: ClusterIP
       # -- The port to use for the langfuse web application
       port: 3000
+      # -- The external port that will be exposed by the service
+      externalPort: 80
       # -- The node port to use for the langfuse web application
       nodePort: null
       # -- Additional labels for the langfuse web application service

--- a/charts/langfuse/values.yaml
+++ b/charts/langfuse/values.yaml
@@ -152,8 +152,8 @@ langfuse:
       type: ClusterIP
       # -- The port to use for the langfuse web application
       port: 3000
-      # -- The external port that will be exposed by the service
-      externalPort: 80
+      # -- The external port that will be exposed by the service. Falls back to `port` if not set.
+      externalPort: null
       # -- The node port to use for the langfuse web application
       nodePort: null
       # -- Additional labels for the langfuse web application service


### PR DESCRIPTION
### Purpose

This PR decouples the target port for the langfuse web container from the external port used by the service. 

### Reasoning

Recently, I wanted to quickly deploy this helm chart and expose it through a LoadBalancer on port 80 like so:

```yaml
langfuse:
  web:
    service:
      type: LoadBalancer
      port: 80 # Affects both the application and service ports
```

However, I got an error because this also changes the port langfuse itself tries to bind to within the container, and port 80 is protected.

To solve this, I added a variable specifically to change the port the service will bind to, without affecting the application port.

```yaml
langfuse:
  web:
    service:
      type: LoadBalancer
      port: 3000 # Application port remains untouched
      externalPort: 80 # Service will bind to port 80
```
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `externalPort` variable to decouple service's external port from application port in Helm chart.
> 
>   - **Behavior**:
>     - Adds `langfuse.web.service.externalPort` to `values.yaml` to specify the external port for the service.
>     - Updates `service.yaml` to use `externalPort` for the service's external binding, decoupling it from the application port.
>   - **Configuration**:
>     - `externalPort` allows setting a different external port (e.g., 80) while keeping the application port unchanged (e.g., 3000).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-k8s&utm_source=github&utm_medium=referral)<sup> for df42d51dfd7d921f12ce6a07d23074e96b2d3ffa. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->