### PR TITLE
chore: bump langfuse version

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -346,6 +346,15 @@ The following configurations have been removed or replaced:
   - Check that all required environment variables are properly migrated to the new structure
   - Any remaining custom environment variables can still be set in `langfuse.additionalEnv`
 
+## Troubleshooting
+
+### Migration Errors
+
+If you encounter a migration error like `no migration found for version 18: read down for version 18 .: file does not exist` during upgrade, this typically happens when a pre-release chart deployed a newer Langfuse version than the major release chart.
+This occurs because pre-release charts may use floating version tags (like `:3`) which can deploy newer application versions with migrations that are not included in specific versioned releases.
+
+**Solution:** Deploy a specific version of the chart that includes all required migrations or overwrite the appVersion configuration to use the latest Langfuse release.
+
 ## Additional Notes
 
 - The chart now supports better separation of concerns between web and worker deployments

--- a/charts/langfuse/Chart.yaml
+++ b/charts/langfuse/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: langfuse
-version: 1.2.8
+version: 1.2.9
 description: Open source LLM engineering platform - LLM observability, metrics, evaluations, prompt management.
 type: application
 keywords:
@@ -40,4 +40,4 @@ maintainers:
     email: contact@langfuse.com
     url: https://langfuse.com/
 icon: https://langfuse.com/langfuse_logo.png
-appVersion: "3.55.0"
+appVersion: "3.57.2"

--- a/charts/langfuse/README.md
+++ b/charts/langfuse/README.md
@@ -1,6 +1,6 @@
 # langfuse
 
-![Version: 1.2.8](https://img.shields.io/badge/Version-1.2.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.55.0](https://img.shields.io/badge/AppVersion-3.55.0-informational?style=flat-square)
+![Version: 1.2.9](https://img.shields.io/badge/Version-1.2.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.57.2](https://img.shields.io/badge/AppVersion-3.57.2-informational?style=flat-square)
 
 Open source LLM engineering platform - LLM observability, metrics, evaluations, prompt management.
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Bump Langfuse Helm chart version to 1.2.9 and app version to 3.57.2, and add migration troubleshooting info.
> 
>   - **Version Bump**:
>     - Update `version` in `Chart.yaml` from `1.2.8` to `1.2.9`.
>     - Update `appVersion` in `Chart.yaml` from `3.55.0` to `3.57.2`.
>     - Update version badge in `README.md` to `1.2.9` and app version badge to `3.57.2`.
>   - **Documentation**:
>     - Add troubleshooting section in `UPGRADE.md` for migration errors related to pre-release charts deploying newer Langfuse versions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-k8s&utm_source=github&utm_medium=referral)<sup> for c666befa53d8ae030efcdc2a0731ddd9f7d6b4bb. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->