### PR TITLE
fix: fallback to minio if its deployed

### DIFF
--- a/charts/langfuse/Chart.yaml
+++ b/charts/langfuse/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: langfuse
-version: 1.2.9
+version: 1.2.10
 description: Open source LLM engineering platform - LLM observability, metrics, evaluations, prompt management.
 type: application
 keywords:
@@ -40,4 +40,4 @@ maintainers:
     email: contact@langfuse.com
     url: https://langfuse.com/
 icon: https://langfuse.com/langfuse_logo.png
-appVersion: "3.57.2"
+appVersion: "3.58.0"

--- a/charts/langfuse/README.md
+++ b/charts/langfuse/README.md
@@ -1,6 +1,6 @@
 # langfuse
 
-![Version: 1.2.9](https://img.shields.io/badge/Version-1.2.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.57.2](https://img.shields.io/badge/AppVersion-3.57.2-informational?style=flat-square)
+![Version: 1.2.10](https://img.shields.io/badge/Version-1.2.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.58.0](https://img.shields.io/badge/AppVersion-3.58.0-informational?style=flat-square)
 
 Open source LLM engineering platform - LLM observability, metrics, evaluations, prompt management.
 

--- a/charts/langfuse/templates/_helpers.tpl
+++ b/charts/langfuse/templates/_helpers.tpl
@@ -366,9 +366,9 @@ Return ClickHouse protocol (http or https)
 - name: LANGFUSE_S3_EVENT_UPLOAD_REGION
   value: {{ .Values.s3.eventUpload.region | default .Values.s3.region | quote }}
 {{- end }}
-{{- if or .Values.s3.eventUpload.endpoint .Values.s3.endpoint }}
+{{- if or .Values.s3.eventUpload.endpoint .Values.s3.endpoint .Values.s3.deploy }}
 - name: LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT
-  value: {{ .Values.s3.eventUpload.endpoint | default .Values.s3.endpoint | quote }}
+  value: {{ .Values.s3.eventUpload.endpoint | default .Values.s3.endpoint | default (include "langfuse.s3.endpoint" .) | quote }}
 {{- end }}
 {{- with (include "langfuse.getS3ValueOrSecret" (dict "key" "accessKeyId" "bucket" "eventUpload" "values" .Values.s3) ) }}
 - name: LANGFUSE_S3_EVENT_UPLOAD_ACCESS_KEY_ID
@@ -423,9 +423,9 @@ Return ClickHouse protocol (http or https)
 - name: LANGFUSE_S3_BATCH_EXPORT_REGION
   value: {{ .Values.s3.batchExport.region | default .Values.s3.region | quote }}
 {{- end }}
-{{- if or .Values.s3.batchExport.endpoint .Values.s3.endpoint }}
+{{- if or .Values.s3.batchExport.endpoint .Values.s3.endpoint .Values.s3.deploy }}
 - name: LANGFUSE_S3_BATCH_EXPORT_ENDPOINT
-  value: {{ .Values.s3.batchExport.endpoint | default .Values.s3.endpoint | quote }}
+  value: {{ .Values.s3.batchExport.endpoint | default .Values.s3.endpoint | default (include "langfuse.s3.endpoint" .) | quote }}
 {{- end }}
 {{- with (include "langfuse.getS3ValueOrSecret" (dict "key" "accessKeyId" "bucket" "batchExport" "values" .Values.s3) ) }}
 - name: LANGFUSE_S3_BATCH_EXPORT_ACCESS_KEY_ID
@@ -478,9 +478,9 @@ Return ClickHouse protocol (http or https)
 - name: LANGFUSE_S3_MEDIA_UPLOAD_REGION
   value: {{ .Values.s3.mediaUpload.region | default .Values.s3.region | quote }}
 {{- end }}
-{{- if or .Values.s3.mediaUpload.endpoint .Values.s3.endpoint }}
+{{- if or .Values.s3.mediaUpload.endpoint .Values.s3.endpoint .Values.s3.deploy }}
 - name: LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT
-  value: {{ .Values.s3.mediaUpload.endpoint | default .Values.s3.endpoint | quote }}
+  value: {{ .Values.s3.mediaUpload.endpoint | default .Values.s3.endpoint | default (include "langfuse.s3.endpoint" .) | quote }}
 {{- end }}
 {{- with (include "langfuse.getS3ValueOrSecret" (dict "key" "accessKeyId" "bucket" "mediaUpload" "values" .Values.s3) ) }}
 - name: LANGFUSE_S3_MEDIA_UPLOAD_ACCESS_KEY_ID


### PR DESCRIPTION
Fixes https://github.com/langfuse/langfuse-k8s/issues/157
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fallback to MinIO for S3 endpoint if deployed, with version updates in `Chart.yaml` and `README.md`.
> 
>   - **Behavior**:
>     - Fallback to MinIO for S3 endpoint if `s3.deploy` is true in `_helpers.tpl`.
>     - Updates S3 endpoint logic for `LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT`, `LANGFUSE_S3_BATCH_EXPORT_ENDPOINT`, and `LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT`.
>   - **Version Updates**:
>     - Bump chart version to `1.2.10` and app version to `3.58.0` in `Chart.yaml` and `README.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-k8s&utm_source=github&utm_medium=referral)<sup> for 245fbf0cf5f3bff2d86cd4f2328be6d940852756. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->