### PR TITLE
[Fix] S3 Validations Azure Blob

### DIFF
--- a/charts/langfuse/Chart.yaml
+++ b/charts/langfuse/Chart.yaml
@@ -19,7 +19,7 @@ dependencies:
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: postgresql.deploy
   - name: clickhouse
-    version: 8.0.5
+    version: 9.2.5
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: clickhouse.deploy
   - name: valkey

--- a/charts/langfuse/README.md
+++ b/charts/langfuse/README.md
@@ -21,7 +21,7 @@ Open source LLM engineering platform - LLM observability, metrics, evaluations, 
 
 | Repository | Name | Version |
 |------------|------|---------|
-| oci://registry-1.docker.io/bitnamicharts | clickhouse | 8.0.5 |
+| oci://registry-1.docker.io/bitnamicharts | clickhouse | 9.2.5 |
 | oci://registry-1.docker.io/bitnamicharts | common | 2.30.0 |
 | oci://registry-1.docker.io/bitnamicharts | s3(minio) | 14.10.5 |
 | oci://registry-1.docker.io/bitnamicharts | postgresql | 16.4.9 |

--- a/charts/langfuse/templates/_helpers.tpl
+++ b/charts/langfuse/templates/_helpers.tpl
@@ -380,9 +380,9 @@ Return ClickHouse protocol (http or https)
 {{- define "langfuse.s3Env" -}}
 - name: LANGFUSE_S3_EVENT_UPLOAD_BUCKET
 {{- if $.Values.s3.deploy }}
-  value: {{ required "s3.[eventUpload].bucket is required" (coalesce .Values.s3.eventUpload.bucket .Values.s3.bucket .Values.s3.defaultBuckets) | quote }}
+  value: {{ (coalesce .Values.s3.eventUpload.bucket .Values.s3.bucket .Values.s3.defaultBuckets) | quote }}
 {{- else }}
-  value: {{ required "s3.[eventUpload].bucket is required" (.Values.s3.eventUpload.bucket | default .Values.s3.bucket) | quote }}
+  value: {{ (.Values.s3.eventUpload.bucket | default .Values.s3.bucket) | quote }}
 {{- end }}
 {{- if .Values.s3.eventUpload.prefix }}
 - name: LANGFUSE_S3_EVENT_UPLOAD_PREFIX
@@ -437,9 +437,9 @@ Return ClickHouse protocol (http or https)
 {{- if $.Values.s3.batchExport.enabled }}
 - name: LANGFUSE_S3_BATCH_EXPORT_BUCKET
 {{- if $.Values.s3.deploy }}
-  value: {{ required "s3.[batchExport].bucket is required" (coalesce .Values.s3.batchExport.bucket .Values.s3.bucket .Values.s3.defaultBuckets) | quote }}
+  value: {{ (coalesce .Values.s3.batchExport.bucket .Values.s3.bucket .Values.s3.defaultBuckets) | quote }}
 {{- else }}
-  value: {{ required "s3.[batchExport].bucket is required" (.Values.s3.batchExport.bucket | default .Values.s3.bucket) | quote }}
+  value: {{ (.Values.s3.batchExport.bucket | default .Values.s3.bucket) | quote }}
 {{- end }}
 {{- if or .Values.s3.batchExport.prefix .Values.s3.prefix }}
 - name: LANGFUSE_S3_BATCH_EXPORT_PREFIX
@@ -492,9 +492,9 @@ Return ClickHouse protocol (http or https)
 {{- end }}
 - name: LANGFUSE_S3_MEDIA_UPLOAD_BUCKET
 {{- if $.Values.s3.deploy }}
-  value: {{ required "s3.[mediaUpload].bucket is required" (coalesce .Values.s3.mediaUpload.bucket .Values.s3.bucket .Values.s3.defaultBuckets) | quote }}
+  value: {{ (coalesce .Values.s3.mediaUpload.bucket .Values.s3.bucket .Values.s3.defaultBuckets) | quote }}
 {{- else }}
-  value: {{ required "s3.[mediaUpload].bucket is required" (.Values.s3.mediaUpload.bucket | default .Values.s3.bucket) | quote }}
+  value: {{ (.Values.s3.mediaUpload.bucket | default .Values.s3.bucket) | quote }}
 {{- end }}
 {{- if or .Values.s3.mediaUpload.prefix .Values.s3.prefix }}
 - name: LANGFUSE_S3_MEDIA_UPLOAD_PREFIX

--- a/charts/langfuse/templates/_helpers.tpl
+++ b/charts/langfuse/templates/_helpers.tpl
@@ -275,12 +275,16 @@ Get value of a specific environment variable from additionalEnv if it exists
     Compare with https://langfuse.com/self-hosting/configuration#environment-variables
 */}}
 {{- define "langfuse.redisEnv" -}}
-{{- if .Values.redis.auth.existingSecret }}
+{{- if or .Values.redis.auth.existingSecret .Values.redis.auth.password }}
 - name: REDIS_PASSWORD
+{{- if .Values.redis.auth.existingSecret }}
   valueFrom:
     secretKeyRef:
       name: {{ .Values.redis.auth.existingSecret }}
       key: {{ required "redis.auth.existingSecretPasswordKey is required when using an existing secret" .Values.redis.auth.existingSecretPasswordKey }}
+{{- else }}
+  value: {{ required "Using an existing secret or redis.auth.password is required" .Values.redis.auth.password | quote }}
+{{- end }}
 {{- end }}
 - name: REDIS_TLS_ENABLED
   value: {{ .Values.redis.tls.enabled | quote }}

--- a/charts/langfuse/templates/_helpers.tpl
+++ b/charts/langfuse/templates/_helpers.tpl
@@ -80,8 +80,6 @@ Return Redis hostname
 {{- .Values.redis.host }}
 {{- else if .Values.redis.deploy }}
 {{- printf "%s-%s-primary" (include "langfuse.fullname" .) (default "redis" .Values.redis.nameOverride) -}}
-{{- else }}
-{{- fail "redis.host must be set when redis.deploy is false" }}
 {{- end }}
 {{- end }}
 
@@ -99,8 +97,6 @@ Return ClickHouse hostname (without protocol)
 {{- end -}}
 {{- else if .Values.clickhouse.deploy }}
 {{- printf "%s-clickhouse" (include "langfuse.fullname" .) -}}
-{{- else }}
-{{- fail "clickhouse.host must be set when clickhouse.deploy is false" }}
 {{- end }}
 {{- end }}
 
@@ -279,14 +275,12 @@ Get value of a specific environment variable from additionalEnv if it exists
     Compare with https://langfuse.com/self-hosting/configuration#environment-variables
 */}}
 {{- define "langfuse.redisEnv" -}}
-- name: REDIS_PASSWORD
 {{- if .Values.redis.auth.existingSecret }}
+- name: REDIS_PASSWORD
   valueFrom:
     secretKeyRef:
       name: {{ .Values.redis.auth.existingSecret }}
       key: {{ required "redis.auth.existingSecretPasswordKey is required when using an existing secret" .Values.redis.auth.existingSecretPasswordKey }}
-{{- else }}
-  value: {{ required "Using an existing secret or redis.auth.password is required" .Values.redis.auth.password | quote }}
 {{- end }}
 - name: REDIS_TLS_ENABLED
   value: {{ .Values.redis.tls.enabled | quote }}
@@ -329,6 +323,7 @@ Return ClickHouse protocol (http or https)
     Compare with https://langfuse.com/self-hosting/configuration#environment-variables
 */}}
 {{- define "langfuse.clickhouseEnv" -}}
+{{ if .Values.clickhouse.deploy }}
 - name: CLICKHOUSE_MIGRATION_URL
   {{- if .Values.clickhouse.migration.url }}
   value: {{ .Values.clickhouse.migration.url | quote }}
@@ -357,6 +352,7 @@ Return ClickHouse protocol (http or https)
 - name: LANGFUSE_AUTO_CLICKHOUSE_MIGRATION_DISABLED
   value: {{ not .Values.clickhouse.migration.autoMigrate | quote }}
 {{- end -}}
+{{- end }}
 
 {{/*
     Get a s3 related config by value or secret. Lookup the bucket value, if not found lookup the shared config.

--- a/charts/langfuse/templates/validations.yaml
+++ b/charts/langfuse/templates/validations.yaml
@@ -39,9 +39,9 @@
     {{- fail "MinIO requires s3 to be deployed with a forcePathStyle. Set s3.forcePathStyle or s3.eventUpload.forcePathStyle to continue." -}}
 {{- end -}}
 
-{{- if and (not $.Values.s3.deploy) (not (or $.Values.s3.bucket $.Values.s3.eventUpload.bucket)) -}}
-    {{- fail "S3 bucket must be configured for external provider. Set s3.bucket or s3.eventUpload.bucket to continue." -}}
-{{- end -}}
+{{- if and (.Values.s3.deploy) (not (or .Values.s3.bucket .Values.s3.eventUpload.bucket)) }}
+    {{- fail "S3 bucket must be configured for external provider. Set s3.bucket or s3.eventUpload.bucket to continue." }}
+{{- end }}
 
 #   Batch Export
 {{- if $.Values.s3.batchExport.enabled -}}
@@ -49,7 +49,7 @@
     {{- fail "MinIO requires s3 to be deployed with a forcePathStyle. Set s3.forcePathStyle or s3.batchExport.forcePathStyle to continue." -}}
 {{- end -}}
 
-{{- if and (not $.Values.s3.deploy) (not (or $.Values.s3.bucket $.Values.s3.batchExport.bucket)) -}}
+{{- if and $.Values.s3.deploy (not (or $.Values.s3.bucket $.Values.s3.batchExport.bucket)) -}}
     {{- fail "S3 bucket must be configured for external provider. Set s3.bucket or s3.batchExport.bucket to continue." -}}
 {{- end -}}
 {{- end -}}
@@ -59,8 +59,8 @@
     {{- fail "MinIO requires s3 to be deployed with a forcePathStyle. Set s3.forcePathStyle or s3.mediaUpload.forcePathStyle to continue." -}}
 {{- end -}}
 
-{{- if and (not $.Values.s3.deploy) (not (or $.Values.s3.bucket $.Values.s3.mediaUpload.bucket)) -}}
-    {{- fail "S3 bucket must be configured for external provider. Set s3.bucket or s3.mediaUpload.bucket to continue." -}}
+{{- if and $.Values.s3.deploy (not (or $.Values.s3.bucket $.Values.s3.batchExport.bucket)) -}}
+    {{- fail "S3 bucket must be configured for external provider. Set s3.bucket or s3.batchExport.bucket to continue." -}}
 {{- end -}}
 
 # Validate that only one of additionalEnv or new structure is configured for PostgreSQL

--- a/charts/langfuse/templates/validations.yaml
+++ b/charts/langfuse/templates/validations.yaml
@@ -20,7 +20,7 @@
     {{- fail "Langfuse does not support ClickHouse with multiple shards. Set clickhouse.shards to 1 to continue." -}}
 {{- end -}}
 
-{{- if and (not $.Values.clickhouse.deploy) (not $.Values.clickhouse.host) -}}
+{{- if and (not $.Values.clickhouse.deploy) (not $.Values.clickhouse.host) (not (include "langfuse.getEnvVar" (dict "env" $.Values.langfuse.additionalEnv "name" "CLICKHOUSE_URL"))) -}}
     {{- fail "ClickHouse host must be configured when using an external ClickHouse instance. Set clickhouse.host to continue." -}}
 {{- end -}}
 
@@ -29,10 +29,9 @@
     {{- fail "Langfuse requires valkey to be deployed with the `--maxmemory-policy noeviction` flag. Set redis.primary.extraFlags to include this flag to continue." -}}
 {{- end -}}
 
-{{- if and (not $.Values.redis.deploy) (not $.Values.redis.host) -}}
+{{- if and (not $.Values.redis.deploy) (not $.Values.redis.host) (not (include "langfuse.getEnvVar" (dict "env" $.Values.langfuse.additionalEnv "name" "REDIS_CONNECTION_STRING"))) -}}
     {{- fail "Redis host must be configured when using an external Redis instance. Set redis.host to continue." -}}
 {{- end -}}
-
 
 # Validate S3 settings
 #   Event Upload
@@ -93,7 +92,7 @@
 {{- if and $.Values.clickhouse.host (include "langfuse.getEnvVar" (dict "env" $.Values.langfuse.additionalEnv "name" "CLICKHOUSE_URL")) -}}
     {{- fail "Only one of additionalEnv or the new structure can be configured. Set either clickhouse configuration or langfuse.additionalEnv[name: CLICKHOUSE_URL] to continue." -}}
 {{- end -}}
-{{- if and $.Values.clickhouse.auth.username (include "langfuse.getEnvVar" (dict "env" $.Values.langfuse.additionalEnv "name" "CLICKHOUSE_USER")) -}}
+{{- if and $.Values.clickhouse.deploy $.Values.clickhouse.auth.username (include "langfuse.getEnvVar" (dict "env" $.Values.langfuse.additionalEnv "name" "CLICKHOUSE_USER")) -}}
     {{- fail "Only one of additionalEnv or the new structure can be configured. Set either clickhouse.auth.username or langfuse.additionalEnv[name: CLICKHOUSE_USER] to continue." -}}
 {{- end -}}
 {{- if and (or $.Values.clickhouse.auth.password $.Values.clickhouse.auth.existingSecret) (include "langfuse.getEnvVar" (dict "env" $.Values.langfuse.additionalEnv "name" "CLICKHOUSE_PASSWORD")) -}}


### PR DESCRIPTION
Branched off of #164, so please merge #164 first, its same idea but for these relevant values:

```yaml
langfuse: 
  # ... not relevant
  additionalEnv:
    # Azure Blob Storage configuration
    - name: LANGFUSE_USE_AZURE_BLOB
      value: "true"
    - name: LANGFUSE_S3_EVENT_UPLOAD_BUCKET
      value: "langfuse"
    - name: LANGFUSE_S3_EVENT_UPLOAD_ACCESS_KEY_ID
      value: "***"
    - name: LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT
      value: "https://***.blob.core.windows.net"
    - name: LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY
      valueFrom:
        secretKeyRef:
          name: langfuse-additional-secrets
          key: LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY
s3:
  deploy: false
```
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improves validation logic for S3/Azure Blob configurations and updates ClickHouse dependency version.
> 
>   - **Validation Logic**:
>     - Updated validation in `validations.yaml` to ensure only one configuration method (either `additionalEnv` or new structure) is used for S3 settings.
>     - Removed redundant validation checks for `redis.host` and `clickhouse.host` in `_helpers.tpl`.
>   - **Dependencies**:
>     - Updated ClickHouse dependency version from `8.0.5` to `9.2.5` in `Chart.yaml` and `README.md`.
>   - **Miscellaneous**:
>     - Minor adjustments to validation messages in `validations.yaml` for clarity.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-k8s&utm_source=github&utm_medium=referral)<sup> for 16943d83112ef6a4619393690f4d125fd68ae926. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->