### PR TITLE
chore: Upgrade clickhouse chart to version 9.2.6

### DIFF
--- a/charts/langfuse/Chart.yaml
+++ b/charts/langfuse/Chart.yaml
@@ -19,7 +19,7 @@ dependencies:
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: postgresql.deploy
   - name: clickhouse
-    version: 8.0.5
+    version: 9.2.6
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: clickhouse.deploy
   - name: valkey


### PR DESCRIPTION
- solve #166
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Upgrade `clickhouse` chart version from 8.0.5 to 9.2.6 in `Chart.yaml`.
> 
>   - **Dependencies**:
>     - Upgrade `clickhouse` chart version from 8.0.5 to 9.2.6 in `Chart.yaml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-k8s&utm_source=github&utm_medium=referral)<sup> for 263684ef0b9a95d8256e9bcd452b5382e4b65992. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->