### PR TITLE
Add pvc sc support

### DIFF
--- a/charts/langfuse/templates/_helpers.tpl
+++ b/charts/langfuse/templates/_helpers.tpl
@@ -584,6 +584,17 @@ Return ClickHouse protocol (http or https)
 {{- end }}
 {{- end -}}
 
+{{- define "defaultStorageClassExists" -}}
+  {{- $storageClasses := (lookup "storage.k8s.io/v1" "StorageClass" "" "").items -}}
+  {{- range $storageClasses -}}
+    {{- if .metadata.annotations -}}
+      {{- if eq (get .metadata.annotations "storageclass.kubernetes.io/is-default-class") "true" -}}
+        {{- true -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
 {{/*
 Common environment variables for all deployments
 */}}

--- a/charts/langfuse/templates/_helpers.tpl
+++ b/charts/langfuse/templates/_helpers.tpl
@@ -592,7 +592,7 @@ Return ClickHouse protocol (http or https)
         {{- true -}}
       {{- end -}}
     {{- end -}}
-  {{- end -}}
+  {{- end }}{{- false -}}
 {{- end -}}
 
 {{/*

--- a/charts/langfuse/templates/validations.yaml
+++ b/charts/langfuse/templates/validations.yaml
@@ -203,3 +203,47 @@
 {{- if and $.Values.langfuse.worker.keda.enabled (or $.Values.langfuse.worker.hpa.enabled $.Values.langfuse.worker.vpa.enabled) -}}
     {{- fail "If keda is enabled for worker component, you cannot enable hpa or vpa. Please disable either keda or both hpa and vpa." -}}
 {{- end -}}
+
+# Validate Web Component PVC
+{{- if .Values.langfuse.web.persistence.enabled }}
+  # Storage class validation
+  {{- if not .Values.langfuse.web.persistence.storageClassName }}
+    {{- if not (include "defaultStorageClassExists" .) }}
+      {{- fail "Web persistence: Storage class must be specified or default storage class must exist" -}}
+    {{- end }}
+  {{- end }}
+
+  # Access modes validation
+  {{- range .Values.langfuse.web.persistence.accessModes }}
+    {{- if not (has . (list "ReadWriteOnce" "ReadOnlyMany" "ReadWriteMany")) }}
+      {{- fail (printf "Web persistence: Invalid access mode '%s'. Valid values: ReadWriteOnce, ReadOnlyMany, ReadWriteMany" .) -}}
+    {{- end }}
+  {{- end }}
+
+  # Size format validation
+  {{- if not (regexMatch "^[1-9]\\d*[KMGTP]i$" .Values.langfuse.web.persistence.size) }}
+    {{- fail "Web persistence: Storage size must be in Kubernetes quantity format (e.g., 10Gi)" -}}
+  {{- end }}
+{{- end }}
+
+# Validate Worker Component PVC
+{{- if .Values.langfuse.worker.persistence.enabled }}
+  # Storage class validation
+  {{- if not .Values.langfuse.worker.persistence.storageClassName }}
+    {{- if not (include "defaultStorageClassExists" .) }}
+      {{- fail "Worker persistence: Storage class must be specified or default storage class must exist" -}}
+    {{- end }}
+  {{- end }}
+
+  # Access modes validation
+  {{- range .Values.langfuse.worker.persistence.accessModes }}
+    {{- if not (has . (list "ReadWriteOnce" "ReadOnlyMany" "ReadWriteMany")) }}
+      {{- fail (printf "Worker persistence: Invalid access mode '%s'. Valid values: ReadWriteOnce, ReadOnlyMany, ReadWriteMany" .) -}}
+    {{- end }}
+  {{- end }}
+
+  # Size format validation
+  {{- if not (regexMatch "^[1-9]\\d*[KMGTP]i$" .Values.langfuse.worker.persistence.size) }}
+    {{- fail "Worker persistence: Storage size must be in Kubernetes quantity format (e.g., 10Gi)" -}}
+  {{- end }}
+{{- end }}

--- a/charts/langfuse/templates/web/pvc.yaml
+++ b/charts/langfuse/templates/web/pvc.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.langfuse.web.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "langfuse.fullname" . }}-web-pvc
+  labels:
+    {{- include "langfuse.labels" . | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.langfuse.web.persistence.annotations | nindent 4 }}
+spec:
+  accessModes:
+    {{- toYaml .Values.langfuse.web.persistence.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.langfuse.web.persistence.size | quote }}
+  {{- if .Values.langfuse.web.persistence.storageClassName }}
+  storageClassName: {{ .Values.langfuse.web.persistence.storageClassName | quote }}
+  {{- end }}
+  {{- if .Values.langfuse.web.persistence.volumeName }}
+  volumeName: {{ .Values.langfuse.web.persistence.volumeName | quote }}
+  {{- end }}
+  {{- with .Values.langfuse.web.persistence.selector }}
+  selector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/langfuse/templates/worker/pvc.yaml
+++ b/charts/langfuse/templates/worker/pvc.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.langfuse.worker.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "langfuse.fullname" . }}-worker-pvc
+  labels:
+    {{- include "langfuse.labels" . | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.langfuse.worker.persistence.annotations | nindent 4 }}
+spec:
+  accessModes:
+    {{- toYaml .Values.langfuse.worker.persistence.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.langfuse.worker.persistence.size | quote }}
+  {{- if .Values.langfuse.worker.persistence.storageClassName }}
+  storageClassName: {{ .Values.langfuse.worker.persistence.storageClassName | quote }}
+  {{- end }}
+  {{- if .Values.langfuse.worker.persistence.volumeName }}
+  volumeName: {{ .Values.langfuse.worker.persistence.volumeName | quote }}
+  {{- end }}
+  {{- with .Values.langfuse.worker.persistence.selector }}
+  selector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/langfuse/values.yaml
+++ b/charts/langfuse/values.yaml
@@ -266,6 +266,29 @@ langfuse:
       failureThreshold: 3
       # -- Success threshold for readinessProbe.
       successThreshold: 1
+    
+    # Persistence configuration for Langfuse components
+    persistence:
+      # -- If enabled, PersistentVolumeClaim will be created.
+      enabled: false
+      # -- Storage class name for persistent volume. Leave empty to use default storage class.
+      storageClassName: ""
+      # -- Size of the persistent volume
+      size: ""
+      # -- Access modes for the persistent volume
+      accessModes:
+        - ReadWriteOnce
+      # -- Annotations for the PersistentVolumeClaim
+      annotations: {}
+        # example: volume.beta.kubernetes.io/storage-class: "standard"
+      # -- Existing PersistentVolume name for static provisioning.
+      # If specified, dynamically provisioned volume will not be used.
+      volumeName: ""
+      # -- Selector for binding to specific PersistentVolumes.
+      selector: {}
+        # example:
+        #   matchLabels:
+        #     type: ssd
 
   # Worker deployment configuration
   worker:
@@ -354,6 +377,29 @@ langfuse:
       failureThreshold: 3
       # -- Success threshold for livenessProbe.
       successThreshold: 1
+    
+    # Persistence configuration for Langfuse components
+    persistence:
+      # -- If enabled, PersistentVolumeClaim will be created.
+      enabled: false
+      # -- Storage class name for persistent volume. Leave empty to use default storage class.
+      storageClassName: ""
+      # -- Size of the persistent volume
+      size: ""
+      # -- Access modes for the persistent volume
+      accessModes:
+        - ReadWriteOnce
+      # -- Annotations for the PersistentVolumeClaim
+      annotations: {}
+        # example: volume.beta.kubernetes.io/storage-class: "standard"
+      # -- Existing PersistentVolume name for static provisioning.
+      # If specified, dynamically provisioned volume will not be used.
+      volumeName: ""
+      # -- Selector for binding to specific PersistentVolumes.
+      selector: {}
+        # example:
+        #   matchLabels:
+        #     type: ssd
 
   # NextAuth configuration
   nextauth:


### PR DESCRIPTION
When deploying Langfuse using the official Helm chart, Persistent Volume Claims (PVCs) remain stuck in Pending state, causing dependent pods to also enter Pending state. And I found related this one (https://github.com/orgs/langfuse/discussions/5655)

Error Message
```
no persistent volumes available for this claim and no storage class is set
```

Root Cause
The current Helm chart does not allow explicit specification of storageClassName in PVC configurations. When no default StorageClass exists in the cluster, PVCs cannot bind to volumes.

Manual Workaround
Currently, users must manually edit PVC manifests post-installation to add storageClassName: VALUE

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds support for specifying storage classes in PVC configurations for Langfuse Helm chart, resolving pending state issues.
> 
>   - **Behavior**:
>     - Adds support for specifying `storageClassName` in PVC configurations for web and worker components in `values.yaml`.
>     - Validates presence of `storageClassName` or default storage class in `validations.yaml`.
>     - Introduces `defaultStorageClassExists` function in `_helpers.tpl` to check for default storage class.
>   - **Templates**:
>     - Adds `web/pvc.yaml` and `worker/pvc.yaml` for PVC definitions with configurable storage class, size, and access modes.
>   - **Validation**:
>     - Updates `validations.yaml` to ensure valid storage class, access modes, and size format for PVCs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-k8s&utm_source=github&utm_medium=referral)<sup> for f7af92bcf31cd17ac9940f6c32ae2294af65a49f. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->