### PR TITLE
fix: adjust placement of hostAliases in web deployment

### DIFF
--- a/charts/langfuse/templates/web/deployment.yaml
+++ b/charts/langfuse/templates/web/deployment.yaml
@@ -15,10 +15,6 @@ spec:
   {{- if not (or .Values.langfuse.web.hpa.enabled .Values.langfuse.web.keda.enabled) }}
   replicas: {{ .Values.langfuse.web.replicas | default .Values.langfuse.replicas }}
   {{- end }}
-  {{- if .Values.langfuse.web.hostAliases }}
-  hostAliases:
-    {{- toYaml .Values.langfuse.web.hostAliases | nindent 8 }}
-  {{- end }}
   {{- with (coalesce .Values.langfuse.web.deployment.strategy .Values.langfuse.deployment.strategy) }}
   strategy:
     {{- toYaml . | nindent 4 }}
@@ -42,6 +38,10 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.langfuse.web.hostAliases }}
+      hostAliases:
+        {{- toYaml .Values.langfuse.web.hostAliases | nindent 8 }}
+      {{- end }}
       {{- with (.Values.langfuse.web.image.pullSecrets | default .Values.langfuse.image.pullSecrets) }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
Fixes https://github.com/langfuse/langfuse-k8s/issues/189
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Moves `hostAliases` configuration to `template.spec` in `web/deployment.yaml` to ensure correct application to pod templates.
> 
>   - **Behavior**:
>     - Moves `hostAliases` configuration from `spec` to `template.spec` in `web/deployment.yaml`.
>     - Ensures `hostAliases` are applied to pod templates, fixing incorrect placement.
>   - **Files**:
>     - Modifies `web/deployment.yaml` to adjust `hostAliases` placement.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-k8s&utm_source=github&utm_medium=referral)<sup> for b62de9626f7224cdb5c8e4cb1007968cee0a2b90. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->