### PR TITLE
chore: Correct Sizing documentation for zookeeper in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ clickhouse:
       cpu: "2"
       memory: "8Gi"
       
-  keeper:
+  zookeeper:
     resources:
       limits:
         cpu: "2"


### PR DESCRIPTION
Fixes wrong yaml sizing reference in readme for zookeeper
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Corrects YAML key from `keeper` to `zookeeper` in `README.md`.
> 
>   - **Documentation**:
>     - Corrects YAML key from `keeper` to `zookeeper` in `README.md` under the Sizing section.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-k8s&utm_source=github&utm_medium=referral)<sup> for 382b467121e41c625964277dde9a52167996eb54. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->