### PR TITLE
chore: document mutual exclusiveness of clickhouse settings

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -27,3 +27,15 @@ this is often due to a misconfigured ClickHouse replication setup.
 This can happen in two cases:
 - **Multi-shard setup**: You've configure more than one ClickHouse shard. Langfuse only supports single-shard setups. Recreate your cluster with a single shard to resolve this.
 - **Moving from single-replica to multi-replica**: If you previously had a single-replica setup and then added a second replica, the tables are not configured for replication. Recreate your cluster with a multi-replica setup to resolve this.
+
+## ClickHouse Configuration Conflicts
+
+If you experience odd connection behavior to ClickHouse, including authentication failures, connection timeouts, or inconsistent connectivity, this may be due to conflicting ClickHouse configurations.
+
+The chart validates that ClickHouse configuration is not set in both the new `clickhouse` structure and the legacy `langfuse.additionalEnv` environment variables simultaneously.
+If you have ClickHouse environment variables in `langfuse.additionalEnv` (such as `CLICKHOUSE_URL`, `CLICKHOUSE_USER`, `CLICKHOUSE_PASSWORD`, `CLICKHOUSE_MIGRATION_URL`), you must either:
+
+1. Remove these from `langfuse.additionalEnv` and use only the new `clickhouse` configuration structure, or
+2. Continue using only `langfuse.additionalEnv` for all ClickHouse settings and avoid setting any values in the `clickhouse` section
+
+Using both approaches simultaneously will cause the chart deployment to fail with validation errors or produce inconsistent results when connecting.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -158,6 +158,9 @@ This guide outlines the changes needed when upgrading from Langfuse Helm Chart v
           existingSecret: <secret-name>
           existingSecretPasswordKey: <password-key>
     ```
+    
+    **⚠️ Important:** The new `clickhouse` configuration structure and `langfuse.additionalEnv` with ClickHouse environment variables are mutually exclusive.
+    You cannot use both approaches simultaneously. If you have ClickHouse configuration in `langfuse.additionalEnv` (e.g., `CLICKHOUSE_URL`, `CLICKHOUSE_USER`, `CLICKHOUSE_PASSWORD`, `CLICKHOUSE_MIGRATION_URL`), you must remove these entries when migrating to the new `clickhouse` configuration structure, or continue using only `langfuse.additionalEnv` for all ClickHouse settings.
 
 4. **S3/MinIO Configuration**
   - The `minio` section has been renamed to `s3`. To keep the same name, you can set the `nameOverride` to `minio`.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Document mutual exclusiveness of ClickHouse settings in `TROUBLESHOOTING.md` and `UPGRADE.md`.
> 
>   - **Documentation**:
>     - Adds section "ClickHouse Configuration Conflicts" to `TROUBLESHOOTING.md` explaining issues with using both `clickhouse` structure and `langfuse.additionalEnv` simultaneously.
>     - Updates `UPGRADE.md` to emphasize that `clickhouse` configuration and `langfuse.additionalEnv` are mutually exclusive and cannot be used together.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-k8s&utm_source=github&utm_medium=referral)<sup> for da7c9bdc874c55b5866a6cc3c6811475a6a50f89. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->