### PR TITLE
allow overriding of redis connection string

### DIFF
--- a/charts/langfuse/templates/_helpers.tpl
+++ b/charts/langfuse/templates/_helpers.tpl
@@ -286,10 +286,12 @@ Get value of a specific environment variable from additionalEnv if it exists
   value: {{ required "Using an existing secret or redis.auth.password is required" .Values.redis.auth.password | quote }}
 {{- end }}
 {{- end }}
+{{- if not (include "langfuse.getEnvVar" (dict "env" $.Values.langfuse.additionalEnv "name" "REDIS_CONNECTION_STRING")) }}
 - name: REDIS_TLS_ENABLED
   value: {{ .Values.redis.tls.enabled | quote }}
 - name: REDIS_CONNECTION_STRING
   value: "{{ if .Values.redis.tls.enabled }}rediss{{ else }}redis{{ end }}://{{ .Values.redis.auth.username }}:$(REDIS_PASSWORD)@{{ include "langfuse.redis.hostname" . }}:{{ .Values.redis.port }}/{{ .Values.redis.auth.database }}"
+{{- end }}
 {{- if .Values.redis.tls.enabled }}
 {{- if .Values.redis.tls.caPath }}
 - name: REDIS_TLS_CA_PATH


### PR DESCRIPTION
Do not include `REDIS_TLS_ENABLED` and `REDIS_CONNECTION_STRING` if `REDIS_CONNECTION_STRING` is set using additionalEnv.

This fixes an issue of `REDIS_CONNECTION_STRING` being set twice in the container specs when providing it via additionalEnv.