### PR TITLE
#205: add more fields to be fetched from secret

### DIFF
--- a/charts/langfuse/templates/validations.yaml
+++ b/charts/langfuse/templates/validations.yaml
@@ -44,7 +44,8 @@
     {{- fail "MinIO requires s3 to be deployed with a forcePathStyle. Set s3.forcePathStyle or s3.eventUpload.forcePathStyle to continue." -}}
 {{- end -}}
 
-{{- if and (not $.Values.s3.deploy) (not (or $.Values.s3.bucket $.Values.s3.eventUpload.bucket)) -}}
+{{- $bucketConfigured := or (and (kindIs "map" $.Values.s3.bucket) (or $.Values.s3.bucket.value $.Values.s3.bucket.secretKeyRef.name)) (and (not (kindIs "map" $.Values.s3.bucket)) $.Values.s3.bucket) (and (kindIs "map" $.Values.s3.eventUpload.bucket) (or $.Values.s3.eventUpload.bucket.value $.Values.s3.eventUpload.bucket.secretKeyRef.name)) (and (not (kindIs "map" $.Values.s3.eventUpload.bucket)) $.Values.s3.eventUpload.bucket) -}}
+{{- if and (not $.Values.s3.deploy) (not $bucketConfigured) -}}
     {{- fail "S3 bucket must be configured for external provider. Set s3.bucket or s3.eventUpload.bucket to continue." -}}
 {{- end -}}
 

--- a/charts/langfuse/values.yaml
+++ b/charts/langfuse/values.yaml
@@ -378,10 +378,18 @@ postgresql:
   # -- Enable PostgreSQL deployment (via Bitnami Helm Chart). If you want to use an external Postgres server (or a managed one), set this to false
   deploy: true
 
-  # -- PostgreSQL host to connect to. If postgresql.deploy is true, this will be set automatically based on the release name.
-  host: ""
-  # -- Port of the postgres server to use. Defaults to 5432.
-  port: null
+  # -- PostgreSQL host to connect to. If postgresql.deploy is true, this will be set automatically based on the release name. Can be configured by value or existing secret reference.
+  host:
+    value: ""
+    secretKeyRef:
+      name: ""
+      key: ""
+  # -- Port of the postgres server to use. Defaults to 5432. Can be configured by value or existing secret reference.
+  port:
+    value: null
+    secretKeyRef:
+      name: ""
+      key: ""
   # -- Additional database connection arguments
   args: ""
 
@@ -391,10 +399,33 @@ postgresql:
   # -- If your database user lacks the CREATE DATABASE permission, you must create a shadow database and configure the "SHADOW_DATABASE_URL". This is often the case if you use a Cloud database. Refer to the Prisma docs for detailed instructions.
   shadowDatabaseUrl: ""
 
+  # -- Optional references to a secret to fetch database connection details
+  secretRefs:
+    # -- Reference to a secret for the database host
+    host:
+      name: ""
+      key: ""
+    # -- Reference to a secret for the database port
+    port:
+      name: ""
+      key: ""
+    # -- Reference to a secret for the database username
+    username:
+      name: ""
+      key: ""
+    # -- Reference to a secret for the database name
+    database:
+      name: ""
+      key: ""
+
   # Authentication configuration
   auth:
-    # -- Username to use to connect to the postgres database deployed with Langfuse. In case `postgresql.deploy` is set to `true`, the user will be created automatically.
-    username: postgres
+    # -- Username to use to connect to the postgres database deployed with Langfuse. In case `postgresql.deploy` is set to `true`, the user will be created automatically. Can be configured by value or existing secret reference.
+    username:
+      value: "postgres"
+      secretKeyRef:
+        name: ""
+        key: ""
     # -- Password to use to connect to the postgres database deployed with Langfuse. In case `postgresql.deploy` is set to `true`, the password will be set automatically.
     password: ""
     # -- If you want to use an existing secret for the postgres password, set the name of the secret here. (`postgresql.auth.username` and `postgresql.auth.password` will be ignored and picked up from this secret).
@@ -402,8 +433,12 @@ postgresql:
     # -- The key in the existing secret that contains the password.
     secretKeys:
       userPasswordKey: password
-    # -- Database name to use for Langfuse.
-    database: postgres_langfuse
+    # -- Database name to use for Langfuse. Can be configured by value or existing secret reference.
+    database:
+      value: "postgres_langfuse"
+      secretKeyRef:
+        name: ""
+        key: ""
     # -- Additional database connection arguments
     args: ""
 
@@ -424,10 +459,18 @@ redis:
   # -- Enable valkey deployment (via Bitnami Helm Chart). If you want to use a Redis or Valkey server already deployed, set to false.
   deploy: true
 
-  # -- Redis host to connect to. If redis.deploy is true, this will be set automatically based on the release name.
-  host: ""
-  # -- Redis port to connect to.
-  port: 6379
+  # -- Redis host to connect to. If redis.deploy is true, this will be set automatically based on the release name. Can be configured by value or existing secret reference.
+  host:
+    value: ""
+    secretKeyRef:
+      name: ""
+      key: ""
+  # -- Redis port to connect to. Can be configured by value or existing secret reference.
+  port:
+    value: 6379
+    secretKeyRef:
+      name: ""
+      key: ""
 
   # Redis TLS configuration
   tls:
@@ -442,8 +485,12 @@ redis:
 
   # Authentication configuration
   auth:
-    # -- Username to use to connect to the redis database deployed with Langfuse. In case `redis.deploy` is set to `true`, the user will be created automatically. Set to null for an empty username in the connection string.
-    username: "default"
+    # -- Username to use to connect to the redis database deployed with Langfuse. In case `redis.deploy` is set to `true`, the user will be created automatically. Set to null for an empty username in the connection string. Can be configured by value or existing secret reference.
+    username:
+      value: "default"
+      secretKeyRef:
+        name: ""
+        key: ""
     # -- Configure the password by value or existing secret reference. Use URL-encoded passwords or avoid special characters in the password.
     password: ""
     # -- If you want to use an existing secret for the redis password, set the name of the secret here. (`redis.auth.password` will be ignored and picked up from this secret).

--- a/charts/langfuse/values.yaml
+++ b/charts/langfuse/values.yaml
@@ -519,6 +519,12 @@ redis:
   # Subchart specific settings
   architecture: standalone
   primary:
+  # -- Optional: Direct Redis connection string. If set, takes precedence over host/port/username/password. Can be configured by value or secretKeyRef.
+  connectionString:
+    value: ""
+    secretKeyRef:
+      name: ""
+      key: ""
     # -- Extra flags for the valkey deployment. Must include `--maxmemory-policy noeviction`.
     extraFlags:
       - "--maxmemory-policy noeviction"
@@ -576,12 +582,24 @@ s3:
   # -- When set to 's3', uses S3-compatible interface (default behavior)
   storageProvider: "s3"
 
-  # -- S3 bucket to use for all uploads. Can be overridden per upload type.
-  bucket: ""
-  # -- S3 region to use for all uploads. Can be overridden per upload type.
-  region: "auto"
-  # -- S3 endpoint to use for all uploads. Can be overridden per upload type.
-  endpoint: ""
+  # -- S3 bucket to use for all uploads. Can be overridden per upload type. Can be configured by value or existing secret reference.
+  bucket:
+    value: ""
+    secretKeyRef:
+      name: ""
+      key: ""
+  # -- S3 region to use for all uploads. Can be overridden per upload type. Can be configured by value or existing secret reference.
+  region:
+    value: "auto"
+    secretKeyRef:
+      name: ""
+      key: ""
+  # -- S3 endpoint to use for all uploads. Can be overridden per upload type. Can be configured by value or existing secret reference.
+  endpoint:
+    value: ""
+    secretKeyRef:
+      name: ""
+      key: ""
   # -- Whether to force path style on requests. Required for MinIO. Can be overridden per upload type.
   forcePathStyle: true
   # -- S3 accessKeyId to use for all uploads. Can be overridden per upload type.
@@ -619,13 +637,25 @@ s3:
   # Event Upload Configuration
   eventUpload:
     # -- S3 bucket to use for event uploads.
-    bucket: ""
+    bucket:
+      value: ""
+      secretKeyRef:
+        name: ""
+        key: ""
     # -- Prefix to use for event uploads within the bucket.
     prefix: ""
-    # -- S3 region to use for event uploads.
-    region: ""
-    # -- S3 endpoint to use for event uploads.
-    endpoint: ""
+    # -- S3 region to use for event uploads. Can be configured by value or existing secret reference.
+    region:
+      value: ""
+      secretKeyRef:
+        name: ""
+        key: ""
+    # -- S3 endpoint to use for event uploads. Can be configured by value or existing secret reference.
+    endpoint:
+      value: ""
+      secretKeyRef:
+        name: ""
+        key: ""
     # -- Whether to force path style on requests. Required for MinIO.
     forcePathStyle: Null
     # -- S3 accessKeyId to use for event uploads.
@@ -646,13 +676,25 @@ s3:
     # -- Enable batch export.
     enabled: true
     # -- S3 bucket to use for batch exports.
-    bucket: ""
+    bucket:
+      value: ""
+      secretKeyRef:
+        name: ""
+        key: ""
     # -- Prefix to use for batch exports within the bucket.
     prefix: ""
-    # -- S3 region to use for batch exports.
-    region: ""
-    # -- S3 endpoint to use for batch exports.
-    endpoint: ""
+    # -- S3 region to use for batch exports. Can be configured by value or existing secret reference.
+    region:
+      value: ""
+      secretKeyRef:
+        name: ""
+        key: ""
+    # -- S3 endpoint to use for batch exports. Can be configured by value or existing secret reference.
+    endpoint:
+      value: ""
+      secretKeyRef:
+        name: ""
+        key: ""
     # -- Whether to force path style on requests. Required for MinIO.
     forcePathStyle: Null
     # -- S3 accessKeyId to use for batch exports.
@@ -673,13 +715,25 @@ s3:
     # -- Enable media uploads.
     enabled: true
     # -- S3 bucket to use for media uploads.
-    bucket: ""
+    bucket:
+      value: ""
+      secretKeyRef:
+        name: ""
+        key: ""
     # -- Prefix to use for media uploads within the bucket.
     prefix: ""
-    # -- S3 region to use for media uploads.
-    region: ""
-    # -- S3 endpoint to use for media uploads.
-    endpoint: ""
+    # -- S3 region to use for media uploads. Can be configured by value or existing secret reference.
+    region:
+      value: ""
+      secretKeyRef:
+        name: ""
+        key: ""
+    # -- S3 endpoint to use for media uploads. Can be configured by value or existing secret reference.
+    endpoint:
+      value: ""
+      secretKeyRef:
+        name: ""
+        key: ""
     # -- Whether to force path style on requests. Required for MinIO.
     forcePathStyle: Null
     # -- S3 accessKeyId to use for media uploads.

--- a/examples/secret-refs-example.yaml
+++ b/examples/secret-refs-example.yaml
@@ -1,0 +1,93 @@
+# Example: Using secretKeyRef for sensitive values in Langfuse Helm Chart
+# This file demonstrates how to use the new `secretKeyRef` feature to source
+# connection details from Kubernetes secrets for PostgreSQL and Redis.
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: langfuse-db-secrets
+  namespace: default
+type: Opaque
+data:
+  # Base64 encoded values for PostgreSQL
+  POSTGRES_HOST: "cG9zdGdyZXMtaG9zdC5leGFtcGxlLmNvbQ==" # postgres-host.example.com
+  POSTGRES_PORT: "NTQzMg==" # 5432
+  POSTGRES_USER: "bGFuZ2Z1c2VfdXNlcg==" # langfuse_user
+  POSTGRES_DB: "bGFuZ2Z1c2VfZGI=" # langfuse_db
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: langfuse-redis-secrets
+  namespace: default
+type: Opaque
+data:
+  # Base64 encoded values for Redis
+  REDIS_HOST: "cmVkaXMtaG9zdC5leGFtcGxlLmNvbQ==" # redis-host.example.com
+  REDIS_PORT: "NjM3OQ==" # 6379
+  REDIS_USER: "ZGVmYXVsdA==" # default
+
+---
+# Helm values demonstrating the use of `secretKeyRef`.
+# Save this as values.yaml and use with:
+# helm install langfuse ./charts/langfuse -f values.yaml
+
+postgresql:
+  # Set `deploy` to false as we are using an external PostgreSQL instance
+  deploy: false
+
+  # Use the new `secretKeyRef` to point to the Kubernetes secret
+  host:
+    secretKeyRef:
+      name: langfuse-db-secrets
+      key: POSTGRES_HOST
+  port:
+    secretKeyRef:
+      name: langfuse-db-secrets
+      key: POSTGRES_PORT
+
+  # The existing password management is unchanged and can be used alongside
+  auth:
+    existingSecret: "my-postgres-password-secret"
+    secretKeys:
+      userPasswordKey: "password"
+    username:
+      secretKeyRef:
+        name: langfuse-db-secrets
+        key: POSTGRES_USER
+    database:
+      secretKeyRef:
+        name: langfuse-db-secrets
+        key: POSTGRES_DB
+
+redis:
+  # Set `deploy` to false to use an external Redis
+  deploy: false
+
+  host:
+    secretKeyRef:
+      name: langfuse-redis-secrets
+      key: REDIS_HOST
+  port:
+    secretKeyRef:
+      name: langfuse-redis-secrets
+      key: REDIS_PORT
+
+  auth:
+    existingSecret: "my-redis-password-secret"
+    existingSecretPasswordKey: "password"
+    username:
+      secretKeyRef:
+        name: langfuse-redis-secrets
+        key: REDIS_USER
+
+# Other configurations remain as needed...
+langfuse:
+  nextauth:
+    url: "https://langfuse.example.com"
+    secret:
+      # The standard secretKeyRef for other values remains unchanged
+      secretKeyRef:
+        name: "my-langfuse-app-secrets"
+        key: "nextauth-secret"


### PR DESCRIPTION
This PR:
- Allows more fields to be referenced from secretRef. 

NOTE:
- please mention if anymore needs to be considered. 


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add support for fetching PostgreSQL and Redis configuration fields from Kubernetes secrets in Helm chart.
> 
>   - **Behavior**:
>     - Extend `langfuse.getValueOrSecret` usage in `_helpers.tpl` to support `postgresql` and `redis` fields: `host`, `port`, `username`, and `database`.
>     - Add secret reference support for `postgresql` and `redis` configurations in `values.yaml`.
>   - **Examples**:
>     - Add `secret-refs-example.yaml` to demonstrate using `secretKeyRef` for PostgreSQL and Redis configurations.
>   - **Misc**:
>     - Update `REDIS_CONNECTION_STRING` logic in `_helpers.tpl` to handle secret references for `host`, `port`, and `username`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-k8s&utm_source=github&utm_medium=referral)<sup> for f10a7bdcdfa7acc6b629a40caf6ed807c6bb77e3. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->