### PR TITLE
Allow extra container per pod type

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Install helm-unittest plugin
         run: |
-          helm plugin install https://github.com/helm-unittest/helm-unittest.git --version v0.6.2
+          helm plugin install https://github.com/helm-unittest/helm-unittest.git --version v1.0.0
 
       - name: Update dependencies
         run: helm dependency update charts/langfuse/

--- a/charts/langfuse/templates/web/deployment.yaml
+++ b/charts/langfuse/templates/web/deployment.yaml
@@ -58,8 +58,9 @@ spec:
         {{- toYaml .Values.langfuse.extraVolumes | nindent 8 }}
       {{- end }}
       containers:
-        {{- if .Values.langfuse.extraContainers }}
-        {{- toYaml .Values.langfuse.extraContainers | nindent 8 }}
+        {{- $additionalContainers := concat (.Values.langfuse.extraContainers | default list ) (.Values.langfuse.web.pod.extraContainers | default list )}}
+        {{- with $additionalContainers }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
         - name: {{ .Chart.Name }}-web
           securityContext:

--- a/charts/langfuse/templates/worker/deployment.yaml
+++ b/charts/langfuse/templates/worker/deployment.yaml
@@ -54,8 +54,9 @@ spec:
         {{- toYaml .Values.langfuse.extraVolumes | nindent 8 }}
       {{- end }}
       containers:
-        {{- if .Values.langfuse.extraContainers }}
-        {{- toYaml .Values.langfuse.extraContainers | nindent 8 }}
+        {{- $additionalContainers := concat (.Values.langfuse.extraContainers | default list) (.Values.langfuse.worker.pod.extraContainers | default list)}}
+        {{- with $additionalContainers }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
         - name: {{ .Chart.Name }}-worker
           securityContext:

--- a/charts/langfuse/tests/extra-containers_test.yaml
+++ b/charts/langfuse/tests/extra-containers_test.yaml
@@ -1,0 +1,64 @@
+suite: test rendering of extra containers
+templates:
+  - web/deployment.yaml
+  - worker/deployment.yaml
+  - web/service.yaml
+  - serviceaccount.yaml
+tests:
+  - it: should render all for web containers
+    values:
+      - ../../../examples/minimal-installation/values.yaml
+      - ./values/extra-web-containers.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+        template: web/deployment.yaml
+      - isKind:
+          of: Deployment
+        template: web/deployment.yaml
+      - lengthEqual:
+          path: spec.template.spec.containers
+          count: 3
+        template: web/deployment.yaml
+      - lengthEqual:
+          path: spec.template.spec.containers
+          count: 1
+        template: worker/deployment.yaml
+  - it: should render all for worker containers
+    values:
+      - ../../../examples/minimal-installation/values.yaml
+      - ./values/extra-worker-containers.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+        template: web/deployment.yaml
+      - isKind:
+          of: Deployment
+        template: web/deployment.yaml
+      - lengthEqual:
+          path: spec.template.spec.containers
+          count: 1
+        template: web/deployment.yaml
+      - lengthEqual:
+          path: spec.template.spec.containers
+          count: 3
+        template: worker/deployment.yaml
+  - it: should render all containers
+    values:
+      - ../../../examples/minimal-installation/values.yaml
+      - ./values/extra-all-containers.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+        template: web/deployment.yaml
+      - isKind:
+          of: Deployment
+        template: web/deployment.yaml
+      - lengthEqual:
+          path: spec.template.spec.containers
+          count: 4
+        template: web/deployment.yaml
+      - lengthEqual:
+          path: spec.template.spec.containers
+          count: 3
+        template: worker/deployment.yaml

--- a/charts/langfuse/tests/values/extra-all-containers.yaml
+++ b/charts/langfuse/tests/values/extra-all-containers.yaml
@@ -1,0 +1,20 @@
+langfuse:
+  extraContainers:
+    - name: extra-all-container-1
+      image: busybox:latest
+      command: [ "sh", "-c", "echo Hello from extra container 1" ]
+  worker:
+    pod:
+      extraContainers:
+        - name: extra-worker-container-1
+          image: busybox:latest
+          command: ["sh", "-c", "echo Hello from extra container 1"]
+  web:
+    pod:
+      extraContainers:
+        - name: extra-web-container-1
+          image: busybox:latest
+          command: [ "sh", "-c", "echo Hello from extra container 1" ]
+        - name: extra-web-container-2
+          image: busybox:latest
+          command: [ "sh", "-c", "echo Hello from extra container 2" ]

--- a/charts/langfuse/tests/values/extra-web-containers.yaml
+++ b/charts/langfuse/tests/values/extra-web-containers.yaml
@@ -1,0 +1,10 @@
+langfuse:
+  web:
+    pod:
+      extraContainers:
+        - name: extra-web-container-1
+          image: busybox:latest
+          command: ["sh", "-c", "echo Hello from extra container 1"]
+        - name: extra-web-container-2
+          image: busybox:latest
+          command: ["sh", "-c", "echo Hello from extra container 2"]

--- a/charts/langfuse/tests/values/extra-worker-containers.yaml
+++ b/charts/langfuse/tests/values/extra-worker-containers.yaml
@@ -1,0 +1,10 @@
+langfuse:
+  worker:
+    pod:
+      extraContainers:
+        - name: extra-worker-container-1
+          image: busybox:latest
+          command: ["sh", "-c", "echo Hello from extra container 1"]
+        - name: extra-worker-container-2
+          image: busybox:latest
+          command: ["sh", "-c", "echo Hello from extra container 2"]

--- a/charts/langfuse/values.yaml
+++ b/charts/langfuse/values.yaml
@@ -175,6 +175,8 @@ langfuse:
       labels: {}
       # -- Topology spread constraints for the web pods. Overrides the global topologySpreadConstraints
       topologySpreadConstraints: null
+      # -- Allows additional containers to be added to all langfuse web pods
+      extraContainers: []
     service:
       # -- The type of service to use for the langfuse web application
       type: ClusterIP
@@ -297,6 +299,8 @@ langfuse:
       labels: {}
       # -- Topology spread constraints for the worker pods. Overrides the global topologySpreadConstraints
       topologySpreadConstraints: null
+      # -- Allows additional containers to be added to all langfuse worker pods
+      extraContainers: []
 
     # -- Resources for the langfuse worker pods. Defaults to the global resources
     resources: {}


### PR DESCRIPTION
Enhances the flexibility of the Helm chart for Langfuse by allowing users to specify additional containers for both web and worker pods via new configuration options. It updates the deployment templates to merge global and pod-specific extra containers, and adds comprehensive tests to ensure correct rendering. Additionally, the Helm unittest plugin is updated to the latest major version.
