### PR TITLE
Allow for additional environment variables per pod type

### DIFF
--- a/charts/langfuse/README.md
+++ b/charts/langfuse/README.md
@@ -120,6 +120,7 @@ Open source LLM engineering platform - LLM observability, metrics, evaluations, 
 | langfuse.web.livenessProbe.periodSeconds | int | `10` | Period seconds for livenessProbe. |
 | langfuse.web.livenessProbe.successThreshold | int | `1` | Success threshold for livenessProbe. |
 | langfuse.web.livenessProbe.timeoutSeconds | int | `5` | Timeout seconds for livenessProbe. |
+| langfuse.web.pod.additionalEnv | list | `[]` | List of additional environment variables to be added to all langfuse web pods. See [documentation](https://langfuse.com/docs/deployment/self-host#configuring-environment-variables) for details. |
 | langfuse.web.pod.annotations | object | `{}` | Annotations for the web pods |
 | langfuse.web.pod.extraContainers | list | `[]` | Allows additional containers to be added to all langfuse web pods |
 | langfuse.web.pod.labels | object | `{}` | Labels for the web pods |
@@ -168,6 +169,7 @@ Open source LLM engineering platform - LLM observability, metrics, evaluations, 
 | langfuse.worker.livenessProbe.periodSeconds | int | `10` | Period seconds for livenessProbe. |
 | langfuse.worker.livenessProbe.successThreshold | int | `1` | Success threshold for livenessProbe. |
 | langfuse.worker.livenessProbe.timeoutSeconds | int | `5` | Timeout seconds for livenessProbe. |
+| langfuse.worker.pod.additionalEnv | list | `[]` | List of additional environment variables to be added to all langfuse worker pods. See [documentation](https://langfuse.com/docs/deployment/self-host#configuring-environment-variables) for details. |
 | langfuse.worker.pod.annotations | object | `{}` | Annotations for the worker pods |
 | langfuse.worker.pod.extraContainers | list | `[]` | Allows additional containers to be added to all langfuse worker pods |
 | langfuse.worker.pod.labels | object | `{}` | Labels for the worker pods |

--- a/charts/langfuse/templates/web/deployment.yaml
+++ b/charts/langfuse/templates/web/deployment.yaml
@@ -74,8 +74,9 @@ spec:
               value: {{ .Values.langfuse.web.service.port | quote }}
             - name: HOSTNAME
               value: "0.0.0.0"
-            {{- if .Values.langfuse.additionalEnv }}
-              {{- toYaml .Values.langfuse.additionalEnv | nindent 12 }}
+            {{- $additionalEnv := concat (.Values.langfuse.additionalEnv | default list ) (.Values.langfuse.web.pod.additionalEnv | default list )}}
+            {{- with $additionalEnv }}
+              {{- toYaml . | nindent 12 }}
             {{- end }}
           ports:
             - name: http

--- a/charts/langfuse/templates/worker/deployment.yaml
+++ b/charts/langfuse/templates/worker/deployment.yaml
@@ -66,8 +66,9 @@ spec:
           imagePullPolicy: {{ .Values.langfuse.worker.image.pullPolicy | default .Values.langfuse.image.pullPolicy }}
           env:
             {{- include "langfuse.commonEnv" . | nindent 12 }}
-            {{- if .Values.langfuse.additionalEnv }}
-              {{- toYaml .Values.langfuse.additionalEnv | nindent 12 }}
+            {{- $additionalEnv := concat (.Values.langfuse.additionalEnv | default list ) (.Values.langfuse.worker.pod.additionalEnv | default list )}}
+            {{- with $additionalEnv }}
+              {{- toYaml . | nindent 12 }}
             {{- end }}
           ports:
             - name: http

--- a/charts/langfuse/tests/extra-env_test.yaml
+++ b/charts/langfuse/tests/extra-env_test.yaml
@@ -1,0 +1,34 @@
+suite: test rendering of extra environment variables
+templates:
+  - web/deployment.yaml
+  - worker/deployment.yaml
+  - web/service.yaml
+  - serviceaccount.yaml
+tests:
+  - it: should render all variables
+    values:
+      - ../../../examples/minimal-installation/values.yaml
+      - ./values/extra-all-env.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+        template: web/deployment.yaml
+      - isKind:
+          of: Deployment
+        template: web/deployment.yaml
+      - equal:
+          path: spec.template.spec.containers[0].env[-1].value
+          value: "langfuse-web"
+        template: web/deployment.yaml
+      - equal:
+          path: spec.template.spec.containers[0].env[-1].value
+          value: "langfuse-worker"
+        template: worker/deployment.yaml
+      - equal:
+          path: spec.template.spec.containers[0].env[-2].value
+          value: "sample-value"
+        template: worker/deployment.yaml
+      - equal:
+          path: spec.template.spec.containers[0].env[-2].value
+          value: "sample-value"
+        template: web/deployment.yaml

--- a/charts/langfuse/tests/values/extra-all-env.yaml
+++ b/charts/langfuse/tests/values/extra-all-env.yaml
@@ -1,0 +1,14 @@
+langfuse:
+  additionalEnv:
+    - name: SAMPLE_ENV_VAR
+      value: sample-value
+  worker:
+    pod:
+      additionalEnv:
+        - name: OTEL_SERVICE_NAME
+          value: langfuse-worker
+  web:
+    pod:
+      additionalEnv:
+        - name: OTEL_SERVICE_NAME
+          value: langfuse-web

--- a/charts/langfuse/values.yaml
+++ b/charts/langfuse/values.yaml
@@ -179,6 +179,8 @@ langfuse:
       topologySpreadConstraints: null
       # -- Allows additional containers to be added to all langfuse web pods
       extraContainers: []
+      # -- List of additional environment variables to be added to all langfuse web pods. See [documentation](https://langfuse.com/docs/deployment/self-host#configuring-environment-variables) for details.
+      additionalEnv: []
     service:
       # -- The type of service to use for the langfuse web application
       type: ClusterIP
@@ -306,6 +308,8 @@ langfuse:
       topologySpreadConstraints: null
       # -- Allows additional containers to be added to all langfuse worker pods
       extraContainers: []
+      # -- List of additional environment variables to be added to all langfuse worker pods. See [documentation](https://langfuse.com/docs/deployment/self-host#configuring-environment-variables) for details.
+      additionalEnv: []
 
     # -- Resources for the langfuse worker pods. Defaults to the global resources
     resources: {}


### PR DESCRIPTION
This pull request adds support for specifying additional environment variables for both the web and worker pods.

This is specially needed if one wants to have different service names for the built in OTEL tracing, as in most systems just having `web` and `worker` isn't specific enough and having them both under a single name like `langfuse` doesn't do good either.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add support for additional environment variables in web and worker pods to customize OTEL tracing service names in Langfuse Helm chart.
> 
>   - **Behavior**:
>     - Support for additional environment variables for `web` and `worker` pods added in `deployment.yaml` for both web and worker templates.
>     - Allows customization of service names for OTEL tracing.
>   - **Configuration**:
>     - New `additionalEnv` fields in `values.yaml` for `web.pod` and `worker.pod` to specify extra environment variables.
>   - **Testing**:
>     - New test `extra-env_test.yaml` added to verify rendering of additional environment variables in deployments.
>     - Test values provided in `extra-all-env.yaml` to simulate environment variable configuration.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-k8s&utm_source=github&utm_medium=referral)<sup> for be147d4259d0a17ca175f21adf155bc7a07443b0. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->