### PR TITLE
Fix handling of CLICKHOUSE_MIGRATION_URL when clickhouse.host defined

### DIFF
--- a/charts/langfuse/templates/_helpers.tpl
+++ b/charts/langfuse/templates/_helpers.tpl
@@ -362,7 +362,7 @@ Return ClickHouse protocol (http or https)
   {{- if .Values.clickhouse.migration.url }}
   value: {{ .Values.clickhouse.migration.url | quote }}
   {{- else if .Values.clickhouse.host }}
-  value: "clickhouse://{{ .Values.clickhouse.host }}:{{ .Values.clickhouse.nativePort }}"
+  value: "clickhouse://{{ include "langfuse.clickhouse.hostname" . }}:{{ .Values.clickhouse.nativePort }}"
   {{- else if .Values.clickhouse.deploy }}
   value: "clickhouse://{{ include "langfuse.clickhouse.hostname" . }}:{{ .Values.clickhouse.nativePort }}"
   {{- end }}


### PR DESCRIPTION
Fixes #240

When `clickhouse.host` is defined, the `CLICKHOUSE_MIGRATION_URL` was being constructed by directly concatenating `clickhouse://` with the host value. If the host already contained a protocol (like `https://`), this resulted in an invalid URL.

Eg:
```
CLICKHOUSE_MIGRATION_URL: clickhouse://https://<redacted>.us-central1.gcp.clickhouse.cloud:9440
CLICKHOUSE_URL: https://<redacted>.us-central1.gcp.clickhouse.cloud:8443
```

This uses `langfuse.clickhouse.hostname` instead of `.Values.clickhouse.host` in the helper to fix handling of `CLICKHOUSE_MIGRATION_URL` when `clickhouse.host` is defined