### PR TITLE
fix: update comments in values.yaml for existing secret usage

### DIFF
--- a/charts/langfuse/README.md
+++ b/charts/langfuse/README.md
@@ -31,7 +31,7 @@ Open source LLM engineering platform - LLM observability, metrics, evaluations, 
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| clickhouse.auth.existingSecret | string | `""` | If you want to use an existing secret for the ClickHouse password, set the name of the secret here. (`clickhouse.auth.username` and `clickhouse.auth.password` will be ignored and picked up from this secret). |
+| clickhouse.auth.existingSecret | string | `""` | If you want to use an existing secret for the ClickHouse password, set the name of the secret here. (`clickhouse.auth.password` will be ignored and picked up from this secret). |
 | clickhouse.auth.existingSecretKey | string | `""` | The key in the existing secret that contains the password. |
 | clickhouse.auth.password | string | `""` | Password for the ClickHouse user. |
 | clickhouse.auth.username | string | `"default"` | Username for the ClickHouse user. |
@@ -190,7 +190,7 @@ Open source LLM engineering platform - LLM observability, metrics, evaluations, 
 | postgresql.args | string | `""` | Additional database connection arguments |
 | postgresql.auth.args | string | `""` | Additional database connection arguments |
 | postgresql.auth.database | string | `"postgres_langfuse"` | Database name to use for Langfuse. |
-| postgresql.auth.existingSecret | string | `""` | If you want to use an existing secret for the postgres password, set the name of the secret here. (`postgresql.auth.username` and `postgresql.auth.password` will be ignored and picked up from this secret). |
+| postgresql.auth.existingSecret | string | `""` | If you want to use an existing secret for the postgres password, set the name of the secret here. (`postgresql.auth.password` will be ignored and picked up from this secret). |
 | postgresql.auth.password | string | `""` | Password to use to connect to the postgres database deployed with Langfuse. In case `postgresql.deploy` is set to `true`, the password will be set automatically. |
 | postgresql.auth.secretKeys | object | `{"userPasswordKey":"password"}` | The key in the existing secret that contains the password. |
 | postgresql.auth.username | string | `"postgres"` | Username to use to connect to the postgres database deployed with Langfuse. In case `postgresql.deploy` is set to `true`, the user will be created automatically. |
@@ -218,7 +218,7 @@ Open source LLM engineering platform - LLM observability, metrics, evaluations, 
 | redis.tls.enabled | bool | `false` | Set to `true` to enable TLS/SSL encrypted connection to the Redis server |
 | redis.tls.keyPath | string | `""` | Path to the client private key file for mutual TLS authentication |
 | s3.accessKeyId | object | `{"secretKeyRef":{"key":"","name":""},"value":""}` | S3 accessKeyId to use for all uploads. Can be overridden per upload type. |
-| s3.auth.existingSecret | string | `""` | If you want to use an existing secret for the root user password, set the name of the secret here. (`s3.auth.rootUser` and `s3.auth.rootPassword` will be ignored and picked up from this secret). |
+| s3.auth.existingSecret | string | `""` | If you want to use an existing secret for the root user password, set the name of the secret here. (`s3.auth.rootPassword` will be ignored and picked up from this secret). |
 | s3.auth.rootPassword | string | `""` | Password for MinIO root user |
 | s3.auth.rootPasswordSecretKey | string | `""` | Key where the Minio root user password is being stored inside the existing secret `s3.auth.existingSecret` |
 | s3.auth.rootUser | string | `"minio"` | root username |

--- a/charts/langfuse/values.yaml
+++ b/charts/langfuse/values.yaml
@@ -423,7 +423,7 @@ postgresql:
     username: postgres
     # -- Password to use to connect to the postgres database deployed with Langfuse. In case `postgresql.deploy` is set to `true`, the password will be set automatically.
     password: ""
-    # -- If you want to use an existing secret for the postgres password, set the name of the secret here. (`postgresql.auth.username` and `postgresql.auth.password` will be ignored and picked up from this secret).
+    # -- If you want to use an existing secret for the postgres password, set the name of the secret here. (`postgresql.auth.password` will be ignored and picked up from this secret).
     existingSecret: ""
     # -- The key in the existing secret that contains the password.
     secretKeys:
@@ -520,7 +520,7 @@ clickhouse:
     username: default
     # -- Password for the ClickHouse user.
     password: ""
-    # -- If you want to use an existing secret for the ClickHouse password, set the name of the secret here. (`clickhouse.auth.username` and `clickhouse.auth.password` will be ignored and picked up from this secret).
+    # -- If you want to use an existing secret for the ClickHouse password, set the name of the secret here. (`clickhouse.auth.password` will be ignored and picked up from this secret).
     existingSecret: ""
     # -- The key in the existing secret that contains the password.
     existingSecretKey: ""
@@ -690,7 +690,7 @@ s3:
     rootUser: minio
     # -- Password for MinIO root user
     rootPassword: ""
-    # -- If you want to use an existing secret for the root user password, set the name of the secret here. (`s3.auth.rootUser` and `s3.auth.rootPassword` will be ignored and picked up from this secret).
+    # -- If you want to use an existing secret for the root user password, set the name of the secret here. (`s3.auth.rootPassword` will be ignored and picked up from this secret).
     existingSecret: ""
     # -- Key where the Minio root user is being stored inside the existing secret `s3.auth.existingSecret`
     rootUserSecretKey: ""


### PR DESCRIPTION
Fix comments in the chart values to reflect actural implementation

The comments said `postgresql.auth.username` and other username values are not used and picked them up from the secrets when `existingSecret` is set. But the chart uses `postgresql.auth.username` values regardless the `existingSecret` value.

https://github.com/langfuse/langfuse-k8s/blob/b18660010a8013761306b7f76f8f0f97e61d68cb/charts/langfuse/templates/_helpers.tpl#L194-L197
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Corrects comments in `values.yaml` to clarify that only passwords, not usernames, are ignored when `existingSecret` is set for `postgresql`, `clickhouse`, and `s3`.
> 
>   - **Comments Update**:
>     - Corrects comments in `values.yaml` for `postgresql.auth`, `clickhouse.auth`, and `s3.auth` sections.
>     - Clarifies that only `password` is ignored when `existingSecret` is set, not `username`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-k8s&utm_source=github&utm_medium=referral)<sup> for de52b699e96ca0615c3a7c013466094cc6887e40. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->