### PR TITLE
fix: switch repository for valkey metrics exporter

### DIFF
--- a/charts/langfuse/values.yaml
+++ b/charts/langfuse/values.yaml
@@ -490,6 +490,9 @@ redis:
     # -- Extra flags for the valkey deployment. Must include `--maxmemory-policy noeviction`.
     extraFlags:
       - "--maxmemory-policy noeviction"
+  metrics:
+    image:
+      repository: bitnamilegacy/redis-exporter
 
 # ClickHouse Configuration
 clickhouse:


### PR DESCRIPTION
Exporter is also now under bitnamilegacy