### PR TITLE
Update helm chart config to use bitnamilegacy

### DIFF
--- a/charts/langfuse/values.yaml
+++ b/charts/langfuse/values.yaml
@@ -1,5 +1,10 @@
 # Langfuse Helm Chart Configuration
 
+global:
+  security:
+    # -- Allow insecure images to use bitnami legacy repository. Can be set to false if secure images are being used (Paid).
+    allowInsecureImages: true
+
 # -- Override the name for the selector labels, defaults to the chart name
 nameOverride: ""
 
@@ -407,13 +412,18 @@ postgresql:
   # -- If your database user lacks the CREATE DATABASE permission, you must create a shadow database and configure the "SHADOW_DATABASE_URL". This is often the case if you use a Cloud database. Refer to the Prisma docs for detailed instructions.
   shadowDatabaseUrl: ""
 
+  image:
+    # -- Overwrite default repository of helm chart to point to non-paid bitnami images.
+    repository: bitnamilegacy/postgresql
+    # image: docker.io/bitnami/postgresql:17.3.0-debian-12-r1
+
   # Authentication configuration
   auth:
     # -- Username to use to connect to the postgres database deployed with Langfuse. In case `postgresql.deploy` is set to `true`, the user will be created automatically.
     username: postgres
     # -- Password to use to connect to the postgres database deployed with Langfuse. In case `postgresql.deploy` is set to `true`, the password will be set automatically.
     password: ""
-    # -- If you want to use an existing secret for the postgres password, set the name of the secret here. (`postgresql.auth.username` and `postgresql.auth.password` will be ignored and picked up from this secret).
+    # -- If you want to use an existing secret for the postgres password, set the name of the secret here. (`postgresql.auth.password` will be ignored and picked up from this secret).
     existingSecret: ""
     # -- The key in the existing secret that contains the password.
     secretKeys:
@@ -444,6 +454,11 @@ redis:
   host: ""
   # -- Redis port to connect to.
   port: 6379
+
+  image:
+    # -- Overwrite default repository of helm chart to point to non-paid bitnami images.
+    repository: bitnamilegacy/valkey
+    # image: docker.io/bitnami/valkey:8.0.2-debian-12-r2
 
   # Redis TLS configuration
   tls:
@@ -488,13 +503,24 @@ clickhouse:
   # -- ClickHouse native port to connect to.
   nativePort: 9000
 
+  image:
+    # -- Overwrite default repository of helm chart to point to non-paid bitnami images.
+    repository: bitnamilegacy/clickhouse
+    #  image: docker.io/bitnami/clickhouse:25.2.1-debian-12-r0
+
+  zookeeper:
+    image:
+      # -- Overwrite default repository of helm chart to point to non-paid bitnami images.
+      repository: bitnamilegacy/zookeeper
+      # image: docker.io/bitnami/zookeeper:3.9.3-debian-12-r8
+
   # Authentication configuration
   auth:
     # -- Username for the ClickHouse user.
     username: default
     # -- Password for the ClickHouse user.
     password: ""
-    # -- If you want to use an existing secret for the ClickHouse password, set the name of the secret here. (`clickhouse.auth.username` and `clickhouse.auth.password` will be ignored and picked up from this secret).
+    # -- If you want to use an existing secret for the ClickHouse password, set the name of the secret here. (`clickhouse.auth.password` will be ignored and picked up from this secret).
     existingSecret: ""
     # -- The key in the existing secret that contains the password.
     existingSecretKey: ""
@@ -528,6 +554,11 @@ s3:
   # -- When set to 'gcs', enables Google Cloud Storage native integration
   # -- When set to 's3', uses S3-compatible interface (default behavior)
   storageProvider: "s3"
+
+  image:
+    # -- Overwrite default repository of helm chart to point to non-paid bitnami images.
+    repository: bitnamilegacy/minio
+    # image: docker.io/bitnami/minio:2024.12.18-debian-12-r1
 
   # -- S3 bucket to use for all uploads. Can be overridden per upload type.
   bucket: ""
@@ -659,7 +690,7 @@ s3:
     rootUser: minio
     # -- Password for MinIO root user
     rootPassword: ""
-    # -- If you want to use an existing secret for the root user password, set the name of the secret here. (`s3.auth.rootUser` and `s3.auth.rootPassword` will be ignored and picked up from this secret).
+    # -- If you want to use an existing secret for the root user password, set the name of the secret here. (`s3.auth.rootPassword` will be ignored and picked up from this secret).
     existingSecret: ""
     # -- Key where the Minio root user is being stored inside the existing secret `s3.auth.existingSecret`
     rootUserSecretKey: ""


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update Helm chart to use Bitnami legacy repositories for non-paid images and add global security setting for insecure images.
> 
>   - **Helm Chart Configuration**:
>     - Updates image repositories to `bitnamilegacy` for `postgresql`, `redis`, `clickhouse`, `zookeeper`, and `minio` in `values.yaml`.
>     - Adds `global.security.allowInsecureImages` set to `true` to allow use of non-paid Bitnami images.
>   - **Authentication**:
>     - Updates comments to clarify that `auth.username` is not ignored when using existing secrets for `postgresql`, `clickhouse`, and `s3`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-k8s&utm_source=github&utm_medium=referral)<sup> for 3073823eb7b467a13583b87f80be1cef221ba330. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->