### PR TITLE
fix: add HOSTNAME and PORT env for worker

### DIFF
--- a/charts/langfuse/templates/worker/deployment.yaml
+++ b/charts/langfuse/templates/worker/deployment.yaml
@@ -66,6 +66,10 @@ spec:
           imagePullPolicy: {{ .Values.langfuse.worker.image.pullPolicy | default .Values.langfuse.image.pullPolicy }}
           env:
             {{- include "langfuse.commonEnv" . | nindent 12 }}
+            - name: PORT
+              value: "{{ .Values.langfuse.worker.port | default 3030 }}"
+            - name: HOSTNAME
+              value: "0.0.0.0"
             {{- $additionalEnv := concat (.Values.langfuse.additionalEnv | default list ) (.Values.langfuse.worker.pod.additionalEnv | default list )}}
             {{- with $additionalEnv }}
               {{- toYaml . | nindent 12 }}


### PR DESCRIPTION
According to https://github.com/langfuse/langfuse/issues/6774#issuecomment-2871502450 , we need set default PORT and HOSTNAME env
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `PORT` and `HOSTNAME` environment variables to worker deployment in `deployment.yaml`.
> 
>   - **Environment Variables**:
>     - Add `PORT` environment variable with default value `3030` in `deployment.yaml`.
>     - Add `HOSTNAME` environment variable with value `0.0.0.0` in `deployment.yaml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-k8s&utm_source=github&utm_medium=referral)<sup> for 8838ae14f83e98b46bce8daeb42483bd911013db. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->