### PR TITLE
feat: add support for redis cluster mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,76 @@ s3:
     prefix: "media/"
 ```
 
+##### With Redis Cluster
+
+Langfuse supports Redis Cluster mode for high-availability and scalability. Configure Redis in one of two ways:
+
+**Standalone Mode (Default):**
+
+```yaml
+redis:
+  deploy: false  # Set to false for external Redis
+  host: "my-redis.example.com"
+  port: 6379
+  auth:
+    password: "your-password"
+```
+
+**Cluster Mode:**
+
+```yaml
+redis:
+  deploy: false  # Must be false - deployed Redis doesn't support cluster mode
+  cluster:
+    enabled: true
+    nodes:
+      - "redis-node-1:6379"
+      - "redis-node-2:6379"
+      - "redis-node-3:6379"
+      - "redis-node-4:6379"
+      - "redis-node-5:6379"
+      - "redis-node-6:6379"
+  auth:
+    password: "your-cluster-password"
+```
+
+**Redis Cluster with TLS:**
+
+```yaml
+redis:
+  deploy: false
+  cluster:
+    enabled: true
+    nodes:
+      - "redis-node-1:6379"
+      - "redis-node-2:6379"
+      - "redis-node-3:6379"
+  auth:
+    password: "your-cluster-password"
+  tls:
+    enabled: true
+    caPath: "/certs/ca.crt"
+    certPath: "/certs/client.crt"
+    keyPath: "/certs/client.key"
+```
+
+**AWS ElastiCache Example:**
+
+For AWS ElastiCache Redis Cluster, use the configuration endpoint that automatically discovers all cluster nodes:
+
+```yaml
+redis:
+  deploy: false
+  cluster:
+    enabled: true
+    nodes:
+      - "clustercfg.my-redis-cluster.abc123.cache.amazonaws.com:6379"
+  auth:
+    password: "your-auth-token"
+  tls:
+    enabled: true
+```
+
 #### Use custom deployment strategy
 
 ```yaml

--- a/charts/langfuse/README.md
+++ b/charts/langfuse/README.md
@@ -208,6 +208,8 @@ Open source LLM engineering platform - LLM observability, metrics, evaluations, 
 | redis.auth.existingSecretPasswordKey | string | `""` | The key in the existing secret that contains the password. |
 | redis.auth.password | string | `""` | Configure the password by value or existing secret reference. Use URL-encoded passwords or avoid special characters in the password. |
 | redis.auth.username | string | `"default"` | Username to use to connect to the redis database deployed with Langfuse. In case `redis.deploy` is set to `true`, the user will be created automatically. Set to null for an empty username in the connection string. |
+| redis.cluster.enabled | bool | `false` | Set to `true` to enable Redis Cluster mode. When enabled, you must set `redis.deploy` to `false` and provide cluster nodes. |
+| redis.cluster.nodes | list | `[]` | List of Redis cluster nodes in the format "host:port". Example: ["redis-1:6379", "redis-2:6379", "redis-3:6379"] |
 | redis.deploy | bool | `true` | Enable valkey deployment (via Bitnami Helm Chart). If you want to use a Redis or Valkey server already deployed, set to false. |
 | redis.host | string | `""` | Redis host to connect to. If redis.deploy is true, this will be set automatically based on the release name. |
 | redis.image.repository | string | `"bitnamilegacy/valkey"` | Overwrite default repository of helm chart to point to non-paid bitnami images. |

--- a/charts/langfuse/templates/_helpers.tpl
+++ b/charts/langfuse/templates/_helpers.tpl
@@ -309,6 +309,34 @@ Get value of a specific environment variable from additionalEnv if it exists
   value: {{ required "Using an existing secret or redis.auth.password is required" .Values.redis.auth.password | quote }}
 {{- end }}
 {{- end }}
+{{- if .Values.redis.cluster.enabled }}
+{{- if not (include "langfuse.getEnvVar" (dict "env" $.Values.langfuse.additionalEnv "name" "REDIS_CLUSTER_NODES")) }}
+- name: REDIS_CLUSTER_ENABLED
+  value: "true"
+- name: REDIS_CLUSTER_NODES
+  value: {{ join "," .Values.redis.cluster.nodes | quote }}
+{{- if or .Values.redis.auth.existingSecret .Values.redis.auth.password }}
+- name: REDIS_AUTH
+  value: "$(REDIS_PASSWORD)"
+{{- end }}
+- name: REDIS_TLS_ENABLED
+  value: {{ .Values.redis.tls.enabled | quote }}
+{{- if .Values.redis.tls.enabled }}
+{{- if .Values.redis.tls.caPath }}
+- name: REDIS_TLS_CA_PATH
+  value: {{ .Values.redis.tls.caPath | quote }}
+{{- end }}
+{{- if .Values.redis.tls.certPath }}
+- name: REDIS_TLS_CERT_PATH
+  value: {{ .Values.redis.tls.certPath | quote }}
+{{- end }}
+{{- if .Values.redis.tls.keyPath }}
+- name: REDIS_TLS_KEY_PATH
+  value: {{ .Values.redis.tls.keyPath | quote }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- else }}
 {{- if not (include "langfuse.getEnvVar" (dict "env" $.Values.langfuse.additionalEnv "name" "REDIS_CONNECTION_STRING")) }}
 - name: REDIS_TLS_ENABLED
   value: {{ .Values.redis.tls.enabled | quote }}
@@ -327,6 +355,7 @@ Get value of a specific environment variable from additionalEnv if it exists
 {{- if .Values.redis.tls.keyPath }}
 - name: REDIS_TLS_KEY_PATH
   value: {{ .Values.redis.tls.keyPath | quote }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end -}}

--- a/charts/langfuse/templates/validations.yaml
+++ b/charts/langfuse/templates/validations.yaml
@@ -29,8 +29,25 @@
     {{- fail "Langfuse requires valkey to be deployed with the `--maxmemory-policy noeviction` flag. Set redis.primary.extraFlags to include this flag to continue." -}}
 {{- end -}}
 
-{{- if and (not $.Values.redis.deploy) (not $.Values.redis.host) (not (include "langfuse.getEnvVar" (dict "env" $.Values.langfuse.additionalEnv "name" "REDIS_CONNECTION_STRING"))) -}}
-    {{- fail "Redis host must be configured when using an external Redis instance. Set redis.host to continue." -}}
+{{- if and (not $.Values.redis.deploy) (not $.Values.redis.host) (not $.Values.redis.cluster.enabled) (not (include "langfuse.getEnvVar" (dict "env" $.Values.langfuse.additionalEnv "name" "REDIS_CONNECTION_STRING"))) -}}
+    {{- fail "Redis host must be configured when using an external Redis instance. Set redis.host or enable redis.cluster.enabled to continue." -}}
+{{- end -}}
+
+{{- if and $.Values.redis.host (include "langfuse.getEnvVar" (dict "env" $.Values.langfuse.additionalEnv "name" "REDIS_CONNECTION_STRING")) -}}
+    {{- fail "Only one of additionalEnv or the new structure can be configured. Set either redis configuration or langfuse.additionalEnv[name: REDIS_CONNECTION_STRING] to continue." -}}
+{{- end -}}
+
+# Validate Redis Cluster settings
+{{- if and $.Values.redis.cluster.enabled (eq (len $.Values.redis.cluster.nodes) 0) (not (include "langfuse.getEnvVar" (dict "env" $.Values.langfuse.additionalEnv "name" "REDIS_CLUSTER_NODES"))) -}}
+    {{- fail "Redis cluster nodes must be configured when cluster mode is enabled. Set redis.cluster.nodes or langfuse.additionalEnv[name: REDIS_CLUSTER_NODES] to continue." -}}
+{{- end -}}
+
+{{- if and $.Values.redis.cluster.nodes (include "langfuse.getEnvVar" (dict "env" $.Values.langfuse.additionalEnv "name" "REDIS_CLUSTER_NODES")) -}}
+    {{- fail "Only one of additionalEnv or the new structure can be configured. Set either redis.cluster.nodes or langfuse.additionalEnv[name: REDIS_CLUSTER_NODES] to continue." -}}
+{{- end -}}
+
+{{- if and $.Values.redis.deploy $.Values.redis.cluster.enabled -}}
+    {{- fail "Redis cluster mode cannot be used with deployed Redis (redis.deploy: true). The deployed Redis is standalone/sentinel architecture. Set redis.deploy to false and configure external Redis cluster nodes to continue." -}}
 {{- end -}}
 
 # Validate S3 settings

--- a/charts/langfuse/tests/redis-cluster_test.yaml
+++ b/charts/langfuse/tests/redis-cluster_test.yaml
@@ -1,0 +1,440 @@
+suite: test redis cluster configuration
+templates:
+  - web/deployment.yaml
+  - worker/deployment.yaml
+  - validations.yaml
+tests:
+  # =====================================================
+  # STANDALONE MODE TESTS
+  # =====================================================
+
+  - it: should use REDIS_CONNECTION_STRING for default standalone deployed Redis
+    values:
+      - ../values.lint.yaml
+    set:
+      redis.deploy: true
+      redis.auth.password: "testPassword123"
+    asserts:
+      # Web deployment should have REDIS_CONNECTION_STRING
+      - matchRegex:
+          path: spec.template.spec.containers[0].env[?(@.name == "REDIS_CONNECTION_STRING")].value
+          pattern: "^redis://.*"
+        template: web/deployment.yaml
+      # Web deployment should NOT have REDIS_CLUSTER_ENABLED
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_CLUSTER_ENABLED
+        template: web/deployment.yaml
+      # Worker deployment should have REDIS_CONNECTION_STRING
+      - matchRegex:
+          path: spec.template.spec.containers[0].env[?(@.name == "REDIS_CONNECTION_STRING")].value
+          pattern: "^redis://.*"
+        template: worker/deployment.yaml
+      # Worker deployment should NOT have REDIS_CLUSTER_ENABLED
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_CLUSTER_ENABLED
+        template: worker/deployment.yaml
+
+  - it: should use REDIS_CONNECTION_STRING for external standalone Redis
+    values:
+      - ../values.lint.yaml
+    set:
+      redis.deploy: false
+      redis.cluster.enabled: false
+      redis.host: "my-redis.example.com"
+      redis.port: 6379
+      redis.auth.password: "testPassword123"
+    asserts:
+      # Web deployment should have REDIS_CONNECTION_STRING
+      - matchRegex:
+          path: spec.template.spec.containers[0].env[?(@.name == "REDIS_CONNECTION_STRING")].value
+          pattern: "^redis://.*"
+        template: web/deployment.yaml
+      # Web deployment should NOT have REDIS_CLUSTER_ENABLED
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_CLUSTER_ENABLED
+        template: web/deployment.yaml
+      # Worker deployment should have REDIS_CONNECTION_STRING
+      - matchRegex:
+          path: spec.template.spec.containers[0].env[?(@.name == "REDIS_CONNECTION_STRING")].value
+          pattern: "^redis://.*"
+        template: worker/deployment.yaml
+
+  - it: should enable TLS for standalone Redis when TLS is enabled
+    values:
+      - ../values.lint.yaml
+    set:
+      redis.deploy: false
+      redis.host: "my-redis.example.com"
+      redis.auth.password: "testPassword123"
+      redis.tls.enabled: true
+      redis.tls.caPath: "/certs/ca.crt"
+    asserts:
+      # Web deployment should have REDIS_TLS_ENABLED=true
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_TLS_ENABLED
+            value: "true"
+        template: web/deployment.yaml
+      # Web deployment should have REDIS_TLS_CA_PATH
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_TLS_CA_PATH
+            value: "/certs/ca.crt"
+        template: web/deployment.yaml
+      # Worker deployment should have REDIS_TLS_ENABLED=true
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_TLS_ENABLED
+            value: "true"
+        template: worker/deployment.yaml
+
+  # =====================================================
+  # CLUSTER MODE TESTS
+  # =====================================================
+
+  - it: should set cluster environment variables when cluster mode is enabled
+    values:
+      - ../values.lint.yaml
+    set:
+      redis.deploy: false
+      redis.cluster.enabled: true
+      redis.cluster.nodes:
+        - "redis-1:6379"
+        - "redis-2:6379"
+        - "redis-3:6379"
+      redis.auth.password: "testPassword123"
+    asserts:
+      # Web deployment should have REDIS_CLUSTER_ENABLED=true
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_CLUSTER_ENABLED
+            value: "true"
+        template: web/deployment.yaml
+      # Web deployment should have REDIS_CLUSTER_NODES
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_CLUSTER_NODES
+            value: "redis-1:6379,redis-2:6379,redis-3:6379"
+        template: web/deployment.yaml
+      # Web deployment should NOT have REDIS_CONNECTION_STRING in cluster mode
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_CONNECTION_STRING
+        template: web/deployment.yaml
+      # Worker deployment should have REDIS_CLUSTER_ENABLED=true
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_CLUSTER_ENABLED
+            value: "true"
+        template: worker/deployment.yaml
+      # Worker deployment should have REDIS_CLUSTER_NODES
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_CLUSTER_NODES
+            value: "redis-1:6379,redis-2:6379,redis-3:6379"
+        template: worker/deployment.yaml
+
+  - it: should set REDIS_AUTH in cluster mode when password is configured
+    values:
+      - ../values.lint.yaml
+    set:
+      redis.deploy: false
+      redis.cluster.enabled: true
+      redis.cluster.nodes:
+        - "redis-1:6379"
+        - "redis-2:6379"
+      redis.auth.password: "clusterPassword"
+    asserts:
+      # Web deployment should have REDIS_AUTH
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_AUTH
+            value: "$(REDIS_PASSWORD)"
+        template: web/deployment.yaml
+      # Web deployment should have REDIS_PASSWORD
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_PASSWORD
+            value: "clusterPassword"
+        template: web/deployment.yaml
+      # Worker deployment should have REDIS_AUTH
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_AUTH
+            value: "$(REDIS_PASSWORD)"
+        template: worker/deployment.yaml
+
+  - it: should enable TLS for cluster mode when TLS is enabled
+    values:
+      - ../values.lint.yaml
+    set:
+      redis.deploy: false
+      redis.cluster.enabled: true
+      redis.cluster.nodes:
+        - "redis-1:6379"
+        - "redis-2:6379"
+      redis.auth.password: "testPassword123"
+      redis.tls.enabled: true
+      redis.tls.caPath: "/certs/ca.crt"
+      redis.tls.certPath: "/certs/client.crt"
+      redis.tls.keyPath: "/certs/client.key"
+    asserts:
+      # Web deployment should have REDIS_TLS_ENABLED=true
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_TLS_ENABLED
+            value: "true"
+        template: web/deployment.yaml
+      # Web deployment should have all TLS paths
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_TLS_CA_PATH
+            value: "/certs/ca.crt"
+        template: web/deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_TLS_CERT_PATH
+            value: "/certs/client.crt"
+        template: web/deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_TLS_KEY_PATH
+            value: "/certs/client.key"
+        template: web/deployment.yaml
+      # Worker deployment should have REDIS_TLS_ENABLED=true
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_TLS_ENABLED
+            value: "true"
+        template: worker/deployment.yaml
+
+  - it: should work with single cluster node (for testing scenarios)
+    values:
+      - ../values.lint.yaml
+    set:
+      redis.deploy: false
+      redis.cluster.enabled: true
+      redis.cluster.nodes:
+        - "redis-single:6379"
+      redis.auth.password: "testPassword123"
+    asserts:
+      # Web deployment should have REDIS_CLUSTER_ENABLED=true
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_CLUSTER_ENABLED
+            value: "true"
+        template: web/deployment.yaml
+      # Web deployment should have REDIS_CLUSTER_NODES with single node
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_CLUSTER_NODES
+            value: "redis-single:6379"
+        template: web/deployment.yaml
+
+  # =====================================================
+  # OVERRIDE TESTS (additionalEnv)
+  # =====================================================
+
+  - it: should skip Redis env generation when REDIS_CONNECTION_STRING is in additionalEnv
+    values:
+      - ../values.lint.yaml
+    set:
+      redis.deploy: false
+      langfuse.additionalEnv:
+        - name: REDIS_CONNECTION_STRING
+          value: "redis://custom:password@custom-host:6380/1"
+    asserts:
+      # Web deployment should have the custom REDIS_CONNECTION_STRING from additionalEnv
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_CONNECTION_STRING
+            value: "redis://custom:password@custom-host:6380/1"
+        template: web/deployment.yaml
+      # Web deployment should NOT have auto-generated REDIS_TLS_ENABLED
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_TLS_ENABLED
+            value: "false"
+        template: web/deployment.yaml
+
+  - it: should skip cluster nodes generation when REDIS_CLUSTER_NODES is in additionalEnv
+    values:
+      - ../values.lint.yaml
+    set:
+      redis.deploy: false
+      redis.cluster.enabled: true
+      redis.auth.password: "testPassword123"
+      langfuse.additionalEnv:
+        - name: REDIS_CLUSTER_NODES
+          value: "custom-1:6379,custom-2:6379"
+    asserts:
+      # Web deployment should have the custom REDIS_CLUSTER_NODES from additionalEnv
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_CLUSTER_NODES
+            value: "custom-1:6379,custom-2:6379"
+        template: web/deployment.yaml
+
+  # =====================================================
+  # VALIDATION TESTS (These should fail)
+  # =====================================================
+
+  - it: should fail validation when cluster is enabled without nodes
+    values:
+      - ../values.lint.yaml
+    set:
+      redis.deploy: false
+      redis.cluster.enabled: true
+      redis.cluster.nodes: []
+      redis.auth.password: "testPassword123"
+    asserts:
+      - failedTemplate:
+          errorMessage: "Redis cluster nodes must be configured when cluster mode is enabled. Set redis.cluster.nodes or langfuse.additionalEnv[name: REDIS_CLUSTER_NODES] to continue."
+        template: validations.yaml
+
+  - it: should fail validation when cluster is enabled with deploy true
+    values:
+      - ../values.lint.yaml
+    set:
+      redis.deploy: true
+      redis.cluster.enabled: true
+      redis.cluster.nodes:
+        - "redis-1:6379"
+      redis.auth.password: "testPassword123"
+    asserts:
+      - failedTemplate:
+          errorMessage: "Redis cluster mode cannot be used with deployed Redis (redis.deploy: true). The deployed Redis is standalone/sentinel architecture. Set redis.deploy to false and configure external Redis cluster nodes to continue."
+        template: validations.yaml
+
+  - it: should fail validation when both values.yaml nodes and additionalEnv REDIS_CLUSTER_NODES are configured
+    values:
+      - ../values.lint.yaml
+    set:
+      redis.deploy: false
+      redis.cluster.enabled: true
+      redis.cluster.nodes:
+        - "redis-1:6379"
+      redis.auth.password: "testPassword123"
+      langfuse.additionalEnv:
+        - name: REDIS_CLUSTER_NODES
+          value: "custom-1:6379"
+    asserts:
+      - failedTemplate:
+          errorMessage: "Only one of additionalEnv or the new structure can be configured. Set either redis.cluster.nodes or langfuse.additionalEnv[name: REDIS_CLUSTER_NODES] to continue."
+        template: validations.yaml
+
+  # =====================================================
+  # EDGE CASES
+  # =====================================================
+
+  - it: should handle cluster mode without authentication
+    values:
+      - ../values.lint.yaml
+    set:
+      redis.deploy: false
+      redis.cluster.enabled: true
+      redis.cluster.nodes:
+        - "redis-1:6379"
+        - "redis-2:6379"
+      redis.auth.password: ""
+    asserts:
+      # Web deployment should have REDIS_CLUSTER_ENABLED=true
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_CLUSTER_ENABLED
+            value: "true"
+        template: web/deployment.yaml
+      # Web deployment should NOT have REDIS_AUTH when password is empty
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_AUTH
+        template: web/deployment.yaml
+      # Web deployment should NOT have REDIS_PASSWORD when password is empty
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_PASSWORD
+        template: web/deployment.yaml
+
+  - it: should use existing secret for Redis password in cluster mode
+    values:
+      - ../values.lint.yaml
+    set:
+      redis.deploy: false
+      redis.cluster.enabled: true
+      redis.cluster.nodes:
+        - "redis-1:6379"
+      redis.auth.existingSecret: "my-redis-secret"
+      redis.auth.existingSecretPasswordKey: "redis-password"
+    asserts:
+      # Web deployment should have REDIS_PASSWORD from secret
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: "my-redis-secret"
+                key: "redis-password"
+        template: web/deployment.yaml
+      # Web deployment should have REDIS_AUTH referencing REDIS_PASSWORD
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_AUTH
+            value: "$(REDIS_PASSWORD)"
+        template: web/deployment.yaml
+
+  - it: should handle TLS disabled explicitly in cluster mode
+    values:
+      - ../values.lint.yaml
+    set:
+      redis.deploy: false
+      redis.cluster.enabled: true
+      redis.cluster.nodes:
+        - "redis-1:6379"
+      redis.auth.password: "testPassword123"
+      redis.tls.enabled: false
+    asserts:
+      # Web deployment should have REDIS_TLS_ENABLED=false
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_TLS_ENABLED
+            value: "false"
+        template: web/deployment.yaml
+      # Web deployment should NOT have TLS path variables
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_TLS_CA_PATH
+        template: web/deployment.yaml

--- a/charts/langfuse/values.yaml
+++ b/charts/langfuse/values.yaml
@@ -484,6 +484,13 @@ redis:
 
     database: 0
 
+  # Redis Cluster configuration
+  cluster:
+    # -- Set to `true` to enable Redis Cluster mode. When enabled, you must set `redis.deploy` to `false` and provide cluster nodes.
+    enabled: false
+    # -- List of Redis cluster nodes in the format "host:port". Example: ["redis-1:6379", "redis-2:6379", "redis-3:6379"]
+    nodes: []
+
   # Subchart specific settings
   architecture: standalone
   primary:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add support for Redis Cluster mode with configuration, validation, and tests in Helm chart.
> 
>   - **Behavior**:
>     - Adds support for Redis Cluster mode in `values.yaml` with `redis.cluster.enabled` and `redis.cluster.nodes`.
>     - Updates `README.md` and `charts/langfuse/README.md` with configuration examples for Redis Cluster.
>     - Validates Redis Cluster settings in `validations.yaml` to ensure proper configuration.
>   - **Templates**:
>     - Updates `templates/_helpers.tpl` to include Redis Cluster environment variables.
>     - Modifies `templates/validations.yaml` to add validation rules for Redis Cluster mode.
>   - **Tests**:
>     - Adds `redis-cluster_test.yaml` with tests for Redis Cluster configuration, including standalone and cluster mode tests, override tests, validation tests, and edge cases.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-k8s&utm_source=github&utm_medium=referral)<sup> for 0250e900004562ebfc6cc841d096d2e8523b7c52. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->