### PR TITLE
devops: Adding support for envFrom k8s secrets and configmap

### DIFF
--- a/charts/langfuse/README.md
+++ b/charts/langfuse/README.md
@@ -53,6 +53,7 @@ Open source LLM engineering platform - LLM observability, metrics, evaluations, 
 | fullnameOverride | string | `""` | Override the full name of the deployed resources, defaults to a combination of the release name and the name for the selector labels |
 | global.security.allowInsecureImages | bool | `true` | Allow insecure images to use bitnami legacy repository. Can be set to false if secure images are being used (Paid). |
 | langfuse.additionalEnv | list | `[]` | List of additional environment variables to be added to all langfuse deployments. See [documentation](https://langfuse.com/docs/deployment/self-host#configuring-environment-variables) for details. |
+| langfuse.additionalEnvFrom | list | `[]` | Secrets or ConfigMap of additional environment variables to be added to all langfuse deployments. See [documentation](https://langfuse.com/docs/deployment/self-host#configuring-environment-variables) for details. |
 | langfuse.affinity | object | `{}` | Affinity for all langfuse deployments |
 | langfuse.allowedOrganizationCreators | list | `[]` | EE: Langfuse allowed organization creators. See [documentation](https://langfuse.com/self-hosting/organization-creators) |
 | langfuse.deployment.annotations | object | `{}` | Annotations for all langfuse deployments |
@@ -130,6 +131,7 @@ Open source LLM engineering platform - LLM observability, metrics, evaluations, 
 | langfuse.web.pdb.maxUnavailable | string | `""` | Maximum number of unavailable pods during disruptions. Cannot be set simultaneously with minAvailable. Defaults to 1 if neither is set. |
 | langfuse.web.pdb.minAvailable | string | `""` | Minimum number of available pods during disruptions. Cannot be set simultaneously with maxUnavailable. |
 | langfuse.web.pod.additionalEnv | list | `[]` | List of additional environment variables to be added to all langfuse web pods. See [documentation](https://langfuse.com/docs/deployment/self-host#configuring-environment-variables) for details. |
+| langfuse.web.pod.additionalEnvFrom | list | `[]` | Secrets or ConfigMap of additional environment variables to be added to all langfuse web pods. See [documentation](https://langfuse.com/docs/deployment/self-host#configuring-environment-variables) for details. |
 | langfuse.web.pod.affinity | string | `nil` | Affinity for the web pods. Overrides the global affinity |
 | langfuse.web.pod.annotations | object | `{}` | Annotations for the web pods |
 | langfuse.web.pod.extraContainers | list | `[]` | Allows additional containers to be added to all langfuse web pods |
@@ -185,6 +187,7 @@ Open source LLM engineering platform - LLM observability, metrics, evaluations, 
 | langfuse.worker.pdb.maxUnavailable | string | `""` | Maximum number of unavailable pods during disruptions. Cannot be set simultaneously with minAvailable. Defaults to 1 if neither is set. |
 | langfuse.worker.pdb.minAvailable | string | `""` | Minimum number of available pods during disruptions. Cannot be set simultaneously with maxUnavailable. |
 | langfuse.worker.pod.additionalEnv | list | `[]` | List of additional environment variables to be added to all langfuse worker pods. See [documentation](https://langfuse.com/docs/deployment/self-host#configuring-environment-variables) for details. |
+| langfuse.worker.pod.additionalEnvFrom | list | `[]` | Secrets or ConfigMap of additional environment variables to be added to all langfuse worker pods. See [documentation](https://langfuse.com/docs/deployment/self-host#configuring-environment-variables) for details. |
 | langfuse.worker.pod.affinity | string | `nil` | Affinity for the worker pods. Overrides the global affinity |
 | langfuse.worker.pod.annotations | object | `{}` | Annotations for the worker pods |
 | langfuse.worker.pod.extraContainers | list | `[]` | Allows additional containers to be added to all langfuse worker pods |

--- a/charts/langfuse/templates/web/deployment.yaml
+++ b/charts/langfuse/templates/web/deployment.yaml
@@ -79,6 +79,11 @@ spec:
             {{- with $additionalEnv }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
+          {{- $additionalEnvFrom := concat (.Values.langfuse.additionalEnvFrom | default list ) (.Values.langfuse.web.pod.additionalEnvFrom | default list )}}
+          {{- with $additionalEnvFrom }}
+          envFrom:
+            {{ toYaml . | nindent 10 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.langfuse.web.service.port }}

--- a/charts/langfuse/templates/web/deployment.yaml
+++ b/charts/langfuse/templates/web/deployment.yaml
@@ -84,7 +84,7 @@ spec:
           {{- $additionalEnvFrom := concat (.Values.langfuse.additionalEnvFrom | default list ) (.Values.langfuse.web.pod.additionalEnvFrom | default list )}}
           {{- with $additionalEnvFrom }}
           envFrom:
-            {{ toYaml . | nindent 10 }}
+            {{ toYaml . | nindent 12 }}
           {{- end }}
           ports:
             - name: http

--- a/charts/langfuse/templates/worker/deployment.yaml
+++ b/charts/langfuse/templates/worker/deployment.yaml
@@ -71,6 +71,11 @@ spec:
             {{- with $additionalEnv }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
+          {{- $additionalEnvFrom := concat (.Values.langfuse.additionalEnvFrom | default list ) (.Values.langfuse.worker.pod.additionalEnvFrom | default list )}}
+          {{- with $additionalEnvFrom }}
+          envFrom:
+            {{ toYaml . | nindent 10 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.langfuse.worker.port | default 3030 }}

--- a/charts/langfuse/templates/worker/deployment.yaml
+++ b/charts/langfuse/templates/worker/deployment.yaml
@@ -74,7 +74,7 @@ spec:
           {{- $additionalEnvFrom := concat (.Values.langfuse.additionalEnvFrom | default list ) (.Values.langfuse.worker.pod.additionalEnvFrom | default list )}}
           {{- with $additionalEnvFrom }}
           envFrom:
-            {{ toYaml . | nindent 10 }}
+            {{ toYaml . | nindent 12 }}
           {{- end }}
           ports:
             - name: http

--- a/charts/langfuse/values.yaml
+++ b/charts/langfuse/values.yaml
@@ -145,6 +145,8 @@ langfuse:
 
   # -- List of additional environment variables to be added to all langfuse deployments. See [documentation](https://langfuse.com/docs/deployment/self-host#configuring-environment-variables) for details.
   additionalEnv: []
+  # -- Secrets or ConfigMap of additional environment variables to be added to all langfuse deployments. See [documentation](https://langfuse.com/docs/deployment/self-host#configuring-environment-variables) for details.
+  additionalEnvFrom: []
   # -- Allows additional containers to be added to all langfuse deployments
   extraContainers: []
   # -- Allows additional volumes to be added to all langfuse deployments
@@ -186,6 +188,8 @@ langfuse:
       extraContainers: []
       # -- List of additional environment variables to be added to all langfuse web pods. See [documentation](https://langfuse.com/docs/deployment/self-host#configuring-environment-variables) for details.
       additionalEnv: []
+      # -- Secrets or ConfigMap of additional environment variables to be added to all langfuse deployments. See [documentation](https://langfuse.com/docs/deployment/self-host#configuring-environment-variables) for details.
+      additionalEnvFrom: []
     service:
       # -- The type of service to use for the langfuse web application
       type: ClusterIP
@@ -315,7 +319,8 @@ langfuse:
       extraContainers: []
       # -- List of additional environment variables to be added to all langfuse worker pods. See [documentation](https://langfuse.com/docs/deployment/self-host#configuring-environment-variables) for details.
       additionalEnv: []
-
+      # -- Secrets or ConfigMap of additional environment variables to be added to all langfuse deployments. See [documentation](https://langfuse.com/docs/deployment/self-host#configuring-environment-variables) for details.
+      additionalEnvFrom: []
     # -- Resources for the langfuse worker pods. Defaults to the global resources
     resources: {}
 

--- a/charts/langfuse/values.yaml
+++ b/charts/langfuse/values.yaml
@@ -190,7 +190,7 @@ langfuse:
       extraContainers: []
       # -- List of additional environment variables to be added to all langfuse web pods. See [documentation](https://langfuse.com/docs/deployment/self-host#configuring-environment-variables) for details.
       additionalEnv: []
-      # -- Secrets or ConfigMap of additional environment variables to be added to all langfuse deployments. See [documentation](https://langfuse.com/docs/deployment/self-host#configuring-environment-variables) for details.
+      # -- Secrets or ConfigMap of additional environment variables to be added to all langfuse web pods. See [documentation](https://langfuse.com/docs/deployment/self-host#configuring-environment-variables) for details.
       additionalEnvFrom: []
     service:
       # -- The type of service to use for the langfuse web application
@@ -321,7 +321,7 @@ langfuse:
       extraContainers: []
       # -- List of additional environment variables to be added to all langfuse worker pods. See [documentation](https://langfuse.com/docs/deployment/self-host#configuring-environment-variables) for details.
       additionalEnv: []
-      # -- Secrets or ConfigMap of additional environment variables to be added to all langfuse deployments. See [documentation](https://langfuse.com/docs/deployment/self-host#configuring-environment-variables) for details.
+      # -- Secrets or ConfigMap of additional environment variables to be added to all langfuse worker pods. See [documentation](https://langfuse.com/docs/deployment/self-host#configuring-environment-variables) for details.
       additionalEnvFrom: []
     # -- Resources for the langfuse worker pods. Defaults to the global resources
     resources: {}


### PR DESCRIPTION
This PR adding support for envFrom option for both worker and web deployment and global configuration. This is required when we are using CD tools such as ArgoCD or FluxCD, and where we don't want to hardcode the data in the `additionalEnv` section of the helm values. This will allow as to use the external secret with all required data without hard coding it in the helm values file in the repo
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `envFrom` support in web and worker deployments to source environment variables from external secrets or configmaps, enhancing flexibility for CD tools.
> 
>   - **Behavior**:
>     - Adds `envFrom` support in `web/deployment.yaml` and `worker/deployment.yaml` to source environment variables from external secrets or configmaps.
>     - Useful for CD tools like ArgoCD or FluxCD to avoid hardcoding environment variables.
>   - **Configuration**:
>     - Introduces `additionalEnvFrom` in `values.yaml` for global, web, and worker configurations.
>     - Allows specifying secrets or configmaps for environment variables in `values.yaml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-k8s&utm_source=github&utm_medium=referral)<sup> for baa0624117e0320328cdb1475b1a10cd20dfaa77. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->