### PR TITLE
fix: support passwordless Redis by conditionally building auth segment

### DIFF
--- a/charts/langfuse/README.md
+++ b/charts/langfuse/README.md
@@ -208,8 +208,8 @@ Open source LLM engineering platform - LLM observability, metrics, evaluations, 
 | redis.auth.database | int | `0` |  |
 | redis.auth.existingSecret | string | `""` | If you want to use an existing secret for the redis password, set the name of the secret here. (`redis.auth.password` will be ignored and picked up from this secret). |
 | redis.auth.existingSecretPasswordKey | string | `""` | The key in the existing secret that contains the password. |
-| redis.auth.password | string | `""` | Configure the password by value or existing secret reference. Use URL-encoded passwords or avoid special characters in the password. |
-| redis.auth.username | string | `"default"` | Username to use to connect to the redis database deployed with Langfuse. In case `redis.deploy` is set to `true`, the user will be created automatically. Set to null for an empty username in the connection string. |
+| redis.auth.password | string | `""` | Password for Redis authentication. Set to null to disable authentication (for passwordless Redis like AWS ElastiCache without auth). Use URL-encoded passwords or avoid special characters in the password. |
+| redis.auth.username | string | `"default"` | Username for Redis authentication. Set to null to omit username from connection string entirely. In case `redis.deploy` is set to `true`, the user will be created automatically. |
 | redis.cluster.enabled | bool | `false` | Set to `true` to enable Redis Cluster mode. When enabled, you must set `redis.deploy` to `false` and provide cluster nodes. |
 | redis.cluster.nodes | list | `[]` | List of Redis cluster nodes in the format "host:port". Example: ["redis-1:6379", "redis-2:6379", "redis-3:6379"] |
 | redis.deploy | bool | `true` | Enable valkey deployment (via Bitnami Helm Chart). If you want to use a Redis or Valkey server already deployed, set to false. |

--- a/charts/langfuse/tests/redis-cluster_test.yaml
+++ b/charts/langfuse/tests/redis-cluster_test.yaml
@@ -438,3 +438,113 @@ tests:
           content:
             name: REDIS_TLS_CA_PATH
         template: web/deployment.yaml
+
+  # =====================================================
+  # PASSWORDLESS REDIS TESTS (Issue #291, #273)
+  # =====================================================
+
+  - it: should handle standalone mode without authentication (null password and username)
+    values:
+      - ../values.lint.yaml
+    set:
+      redis.deploy: false
+      redis.host: "my-redis.example.com"
+      redis.port: 6379
+      redis.auth.password: null
+      redis.auth.username: null
+    asserts:
+      # Web deployment should have REDIS_CONNECTION_STRING without auth segment
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_CONNECTION_STRING
+            value: "redis://my-redis.example.com:6379/0"
+        template: web/deployment.yaml
+      # Web deployment should NOT have REDIS_PASSWORD when password is null
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_PASSWORD
+        template: web/deployment.yaml
+      # Worker deployment should have same connection string
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_CONNECTION_STRING
+            value: "redis://my-redis.example.com:6379/0"
+        template: worker/deployment.yaml
+
+  - it: should handle standalone mode with username but no password (null password)
+    values:
+      - ../values.lint.yaml
+    set:
+      redis.deploy: false
+      redis.host: "my-redis.example.com"
+      redis.port: 6379
+      redis.auth.password: null
+      redis.auth.username: "default"
+    asserts:
+      # Web deployment should have REDIS_CONNECTION_STRING with username only
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_CONNECTION_STRING
+            value: "redis://default@my-redis.example.com:6379/0"
+        template: web/deployment.yaml
+      # Web deployment should NOT have REDIS_PASSWORD when password is null
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_PASSWORD
+        template: web/deployment.yaml
+
+  - it: should handle standalone mode with TLS but no authentication
+    values:
+      - ../values.lint.yaml
+    set:
+      redis.deploy: false
+      redis.host: "my-redis.example.com"
+      redis.port: 6380
+      redis.auth.password: null
+      redis.auth.username: null
+      redis.tls.enabled: true
+    asserts:
+      # Web deployment should have REDIS_CONNECTION_STRING with rediss:// and no auth
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_CONNECTION_STRING
+            value: "rediss://my-redis.example.com:6380/0"
+        template: web/deployment.yaml
+      # Web deployment should have REDIS_TLS_ENABLED=true
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_TLS_ENABLED
+            value: "true"
+        template: web/deployment.yaml
+
+  - it: should include password segment when password is set (existing behavior)
+    values:
+      - ../values.lint.yaml
+    set:
+      redis.deploy: false
+      redis.host: "my-redis.example.com"
+      redis.port: 6379
+      redis.auth.password: "testPassword123"
+      redis.auth.username: "default"
+    asserts:
+      # Web deployment should have REDIS_CONNECTION_STRING with full auth
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_CONNECTION_STRING
+            value: "redis://default:$(REDIS_PASSWORD)@my-redis.example.com:6379/0"
+        template: web/deployment.yaml
+      # Web deployment should have REDIS_PASSWORD
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_PASSWORD
+            value: "testPassword123"
+        template: web/deployment.yaml

--- a/charts/langfuse/values.yaml
+++ b/charts/langfuse/values.yaml
@@ -475,9 +475,11 @@ redis:
 
   # Authentication configuration
   auth:
-    # -- Username to use to connect to the redis database deployed with Langfuse. In case `redis.deploy` is set to `true`, the user will be created automatically. Set to null for an empty username in the connection string.
+    # -- Username for Redis authentication. Set to null to omit username from connection string entirely.
+    # In case `redis.deploy` is set to `true`, the user will be created automatically.
     username: "default"
-    # -- Configure the password by value or existing secret reference. Use URL-encoded passwords or avoid special characters in the password.
+    # -- Password for Redis authentication. Set to null to disable authentication (for passwordless Redis like AWS ElastiCache without auth).
+    # Use URL-encoded passwords or avoid special characters in the password.
     password: ""
     # -- If you want to use an existing secret for the redis password, set the name of the secret here. (`redis.auth.password` will be ignored and picked up from this secret).
     existingSecret: ""


### PR DESCRIPTION
## Summary

- Fixes the `REDIS_CONNECTION_STRING` to conditionally include the auth segment based on whether `redis.auth.password` and `redis.auth.username` are configured
- When both are set to `null`, the connection string omits the auth segment entirely (e.g., `redis://host:port/db`)
- Allows connections to Redis instances without authentication (e.g., AWS ElastiCache without auth)

## Behavior Matrix

| `redis.auth.password` | `redis.auth.username` | Connection String |
|---|---|---|
| `"mypass"` | `"default"` | `redis://default:$(REDIS_PASSWORD)@host:port/db` |
| `"mypass"` | `null` | `redis://:$(REDIS_PASSWORD)@host:port/db` |
| `null` | `"default"` | `redis://default@host:port/db` |
| `null` | `null` | `redis://host:port/db` |

## Test plan

- [x] Added 4 new test cases for passwordless Redis scenarios
- [x] All 52 helm unit tests pass
- [x] Verified connection string output with `helm template` for each scenario

Fixes #291, fixes #273

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Supports passwordless Redis by conditionally omitting auth segment in connection string based on configuration.
> 
>   - **Behavior**:
>     - Updates `REDIS_CONNECTION_STRING` in `_helpers.tpl` to conditionally include auth segment based on `redis.auth.password` and `redis.auth.username`.
>     - Omits auth segment if both are `null`, allowing passwordless Redis connections.
>     - Supports Redis instances without authentication, such as AWS ElastiCache.
>   - **Configuration**:
>     - Updates `values.yaml` to clarify `redis.auth.password` and `redis.auth.username` usage for passwordless connections.
>     - Modifies `README.md` to reflect changes in Redis authentication configuration.
>   - **Testing**:
>     - Adds 4 test cases in `redis-cluster_test.yaml` for passwordless Redis scenarios.
>     - Verifies connection string output with `helm template` for each scenario.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-k8s&utm_source=github&utm_medium=referral)<sup> for baf48e18aee59636c3dcd973f4654823e607a9af. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->