### PR TITLE
feat: add namespaceOverride support to main chart

### DIFF
--- a/charts/langfuse/README.md
+++ b/charts/langfuse/README.md
@@ -188,6 +188,7 @@ Open source LLM engineering platform - LLM observability, metrics, evaluations, 
 | langfuse.worker.vpa.minAllowed | object | `{}` | The minimum allowed resources for the langfuse worker pods |
 | langfuse.worker.vpa.updatePolicy.updateMode | string | `"Auto"` | The update policy mode for the langfuse worker pods |
 | nameOverride | string | `""` | Override the name for the selector labels, defaults to the chart name |
+| namespaceOverride | string | `""` | Override the namespace for all deployed resources, defaults to the release namespace |
 | postgresql.architecture | string | `"standalone"` |  |
 | postgresql.args | string | `""` | Additional database connection arguments |
 | postgresql.auth.args | string | `""` | Additional database connection arguments |

--- a/charts/langfuse/templates/_helpers.tpl
+++ b/charts/langfuse/templates/_helpers.tpl
@@ -51,6 +51,17 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Return the namespace to use
+*/}}
+{{- define "langfuse.namespace" -}}
+{{- if .Values.namespaceOverride }}
+{{- .Values.namespaceOverride }}
+{{- else }}
+{{- .Release.Namespace }}
+{{- end }}
+{{- end }}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "langfuse.serviceAccountName" -}}

--- a/charts/langfuse/templates/ingress.yaml
+++ b/charts/langfuse/templates/ingress.yaml
@@ -14,7 +14,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ include "langfuse.fullname" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "langfuse.namespace" . }}
   labels:
     {{- include "langfuse.labels" . | nindent 4 }}
     {{- with .Values.langfuse.ingress.additionalLabels }}

--- a/charts/langfuse/templates/nextauth-secret.yaml
+++ b/charts/langfuse/templates/nextauth-secret.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "langfuse.fullname" . }}-nextauth
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "langfuse.namespace" . }}
   labels:
     {{- include "langfuse.labels" . | nindent 4 }}
 data:

--- a/charts/langfuse/templates/postgresql-secret.yaml
+++ b/charts/langfuse/templates/postgresql-secret.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "langfuse.fullname" . }}-postgresql
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "langfuse.namespace" . }}
   labels:
     {{- include "langfuse.labels" . | nindent 4 }}
 type: Opaque

--- a/charts/langfuse/templates/serviceaccount.yaml
+++ b/charts/langfuse/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "langfuse.serviceAccountName" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "langfuse.namespace" . }}
   labels:
     {{- include "langfuse.labels" . | nindent 4 }}
   {{- with .Values.langfuse.serviceAccount.annotations }}

--- a/charts/langfuse/templates/web/deployment.yaml
+++ b/charts/langfuse/templates/web/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "langfuse.fullname" . }}-web
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "langfuse.namespace" . }}
   labels:
     {{- include "langfuse.labels" . | nindent 4 }}
     {{- with .Values.langfuse.web.deployment.additionalLabels }}

--- a/charts/langfuse/templates/web/hpa.yaml
+++ b/charts/langfuse/templates/web/hpa.yaml
@@ -3,7 +3,7 @@ apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "langfuse.fullname" . }}-web
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "langfuse.namespace" . }}
   labels:
     {{- include "langfuse.labels" . | nindent 4 }}
 spec:

--- a/charts/langfuse/templates/web/scaled-object.yaml
+++ b/charts/langfuse/templates/web/scaled-object.yaml
@@ -3,7 +3,7 @@ apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
   name: {{ include "langfuse.fullname" . }}-web
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "langfuse.namespace" . }}
   labels:
     {{- include "langfuse.labels" . | nindent 4 }}
 spec:

--- a/charts/langfuse/templates/web/service.yaml
+++ b/charts/langfuse/templates/web/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "langfuse.fullname" . }}-web
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "langfuse.namespace" . }}
   labels:
     {{- include "langfuse.labels" . | nindent 4 }}
     {{- with .Values.langfuse.web.service.additionalLabels }}

--- a/charts/langfuse/templates/web/vpa.yaml
+++ b/charts/langfuse/templates/web/vpa.yaml
@@ -3,7 +3,7 @@ apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
   name: {{ include "langfuse.fullname" . }}-web
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "langfuse.namespace" . }}
   labels:
     {{- include "langfuse.labels" . | nindent 4 }}
 spec:

--- a/charts/langfuse/templates/worker/deployment.yaml
+++ b/charts/langfuse/templates/worker/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "langfuse.fullname" . }}-worker
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "langfuse.namespace" . }}
   labels:
     {{- include "langfuse.labels" . | nindent 4 }}
     {{- with .Values.langfuse.worker.deployment.additionalLabels }}

--- a/charts/langfuse/templates/worker/hpa.yaml
+++ b/charts/langfuse/templates/worker/hpa.yaml
@@ -3,7 +3,7 @@ apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "langfuse.fullname" . }}-worker
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "langfuse.namespace" . }}
   labels:
     {{- include "langfuse.labels" . | nindent 4 }}
 spec:

--- a/charts/langfuse/templates/worker/scaled-object.yaml
+++ b/charts/langfuse/templates/worker/scaled-object.yaml
@@ -3,7 +3,7 @@ apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
   name: {{ include "langfuse.fullname" . }}-worker
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "langfuse.namespace" . }}
   labels:
     {{- include "langfuse.labels" . | nindent 4 }}
 spec:

--- a/charts/langfuse/templates/worker/vpa.yaml
+++ b/charts/langfuse/templates/worker/vpa.yaml
@@ -3,7 +3,7 @@ apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
   name: {{ include "langfuse.fullname" . }}-worker
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "langfuse.namespace" . }}
   labels:
     {{- include "langfuse.labels" . | nindent 4 }}
 spec:

--- a/charts/langfuse/values.yaml
+++ b/charts/langfuse/values.yaml
@@ -11,6 +11,9 @@ nameOverride: ""
 # -- Override the full name of the deployed resources, defaults to a combination of the release name and the name for the selector labels
 fullnameOverride: ""
 
+# -- Override the namespace for all deployed resources, defaults to the release namespace
+namespaceOverride: ""
+
 # Core Langfuse Configuration
 langfuse:
   # Logging configuration


### PR DESCRIPTION
### Summary
This PR adds `namespaceOverride` to the main chart. 

### Changes
- Add namespaceOverride parameter to values.yaml
- Create langfuse.namespace helper function & update all templates to use namespace helper

### Context
When we need to include this langfuse chart as a dependency of another chart, we need this `namespaceOverride` to set the namespace.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `namespaceOverride` support to Langfuse Helm chart for customizable namespace deployment.
> 
>   - **Behavior**:
>     - Add `namespaceOverride` parameter to `values.yaml` to allow overriding the namespace for all deployed resources.
>     - Update `ingress.yaml`, `nextauth-secret.yaml`, `postgresql-secret.yaml`, `serviceaccount.yaml`, `web/deployment.yaml`, `web/hpa.yaml`, `web/scaled-object.yaml`, `web/service.yaml`, `web/vpa.yaml`, `worker/deployment.yaml`, `worker/hpa.yaml`, `worker/scaled-object.yaml`, `worker/vpa.yaml` to use `langfuse.namespace` helper function for namespace specification.
>   - **Helpers**:
>     - Create `langfuse.namespace` helper function in `_helpers.tpl` to determine the namespace based on `namespaceOverride` or default to the release namespace.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-k8s&utm_source=github&utm_medium=referral)<sup> for 63732b5684b8e4afac9c6f77821caa40f1280da0. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->