### PR TITLE
feat: add automountServiceAccountToken option for service accounts

### DIFF
--- a/charts/langfuse/README.md
+++ b/charts/langfuse/README.md
@@ -94,6 +94,7 @@ Open source LLM engineering platform - LLM observability, metrics, evaluations, 
 | langfuse.salt | object | `{"secretKeyRef":{"key":"","name":""},"value":""}` | Used to hash API keys. Can be configured by value or existing secret reference. To generate a new salt, run `openssl rand -base64 32`. |
 | langfuse.securityContext | object | `{}` | Security context for all langfuse deployments |
 | langfuse.serviceAccount.annotations | object | `{}` | Annotations for the service account |
+| langfuse.serviceAccount.automountServiceAccountToken | bool | `true` | Whether to automount service account token in pods. Set to false to disable automatic mounting of the service account token. |
 | langfuse.serviceAccount.create | bool | `true` | Whether to create a service account for all langfuse deployments |
 | langfuse.serviceAccount.name | string | `""` | Override the name of the service account to use, discovered automatically if not set |
 | langfuse.smtp.connectionUrl | string | `""` | SMTP connection URL. See [documentation](https://langfuse.com/self-hosting/transactional-emails) |

--- a/charts/langfuse/templates/serviceaccount.yaml
+++ b/charts/langfuse/templates/serviceaccount.yaml
@@ -10,4 +10,5 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+automountServiceAccountToken: {{ .Values.langfuse.serviceAccount.automountServiceAccountToken }}
 {{- end }}

--- a/charts/langfuse/templates/web/deployment.yaml
+++ b/charts/langfuse/templates/web/deployment.yaml
@@ -49,6 +49,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "langfuse.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.langfuse.serviceAccount.automountServiceAccountToken }}
       securityContext:
         {{- toYaml .Values.langfuse.podSecurityContext | nindent 8 }}
       {{- if .Values.langfuse.extraInitContainers }}

--- a/charts/langfuse/templates/worker/deployment.yaml
+++ b/charts/langfuse/templates/worker/deployment.yaml
@@ -45,6 +45,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "langfuse.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.langfuse.serviceAccount.automountServiceAccountToken }}
       securityContext:
         {{- toYaml .Values.langfuse.podSecurityContext | nindent 8 }}
       {{- if .Values.langfuse.extraInitContainers }}

--- a/charts/langfuse/values.yaml
+++ b/charts/langfuse/values.yaml
@@ -77,6 +77,8 @@ langfuse:
     annotations: {}
     # -- Override the name of the service account to use, discovered automatically if not set
     name: ""
+    # -- Whether to automount service account token in pods. Set to false to disable automatic mounting of the service account token.
+    automountServiceAccountToken: true
 
   smtp:
     # -- SMTP connection URL. See [documentation](https://langfuse.com/self-hosting/transactional-emails)


### PR DESCRIPTION
#306 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `automountServiceAccountToken` option to control service account token mounting in Helm chart deployments.
> 
>   - **Behavior**:
>     - Adds `automountServiceAccountToken` option to `serviceaccount.yaml`, `web/deployment.yaml`, and `worker/deployment.yaml` to control token mounting.
>     - Default value is `true`, allowing automatic mounting unless explicitly set to `false`.
>   - **Configuration**:
>     - Adds `automountServiceAccountToken` to `values.yaml` under `langfuse.serviceAccount` to enable user configuration.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-k8s&utm_source=github&utm_medium=referral)<sup> for 6ce9630131a25f7d932991992bf24f082f1e4786. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->