### PR TITLE
Fix VPA updateMode YAML parsing by adding quotes

### DIFF
--- a/charts/langfuse/templates/web/vpa.yaml
+++ b/charts/langfuse/templates/web/vpa.yaml
@@ -29,7 +29,7 @@ spec:
   {{- if .Values.langfuse.web.vpa.updatePolicy }}
   updatePolicy:
     {{- with .Values.langfuse.web.vpa.updatePolicy.updateMode }}
-    updateMode: {{ . }}
+    updateMode: {{ . | quote }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/langfuse/templates/worker/vpa.yaml
+++ b/charts/langfuse/templates/worker/vpa.yaml
@@ -29,7 +29,7 @@ spec:
   {{- if .Values.langfuse.worker.vpa.updatePolicy }}
   updatePolicy:
     {{- with .Values.langfuse.worker.vpa.updatePolicy.updateMode }}
-    updateMode: {{ . }}
+    updateMode: {{ . | quote }}
     {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
The VPA templates render updateMode without quotes, causing it to be interpreted as a boolean in YAML 1.1. This breaks deployments on clusters with strict VPA webhook validation (like GKE) with the error:

`admission webhook "gke-vpa.k8s.io" denied the request: json: cannot unmarshal bool into Go struct field PodUpdatePolicy.spec.updatePolicy.updateMode of type v1.UpdateMode`                              
                                                                                                                                                                                                        
The issue occurs when users set `updateMode: "Off"` in values - it gets rendered as unquoted `updateMode: Off`, which YAML interprets as the boolean `false`. The VPA API expects a string enum value.
                                                                                                                                                                                                    
This fix adds the `| quote` Helm filter to ensure the value is always rendered as a properly quoted string.
                                                                                                                                                                                                       
  **Changes:**                                                                                                                                                                                            
  - `templates/web/vpa.yaml`: Quote updateMode value                                                                                                                                                      
  - `templates/worker/vpa.yaml`: Quote updateMode value
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes YAML parsing issue by quoting `updateMode` in VPA templates to prevent boolean misinterpretation.
> 
>   - **Behavior**:
>     - Fixes YAML parsing issue by quoting `updateMode` in `web/vpa.yaml` and `worker/vpa.yaml`.
>     - Prevents `updateMode` from being interpreted as a boolean, ensuring it is treated as a string.
>   - **Files**:
>     - `web/vpa.yaml`: Adds `| quote` to `updateMode`.
>     - `worker/vpa.yaml`: Adds `| quote` to `updateMode`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-k8s&utm_source=github&utm_medium=referral)<sup> for 976c7466962a6df7bc132617ea95351c9065444d. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->