### PR TITLE
feat: add affinity/nodeSelector/tolerations per web/worker deployment

### DIFF
--- a/charts/langfuse/README.md
+++ b/charts/langfuse/README.md
@@ -126,9 +126,12 @@ Open source LLM engineering platform - LLM observability, metrics, evaluations, 
 | langfuse.web.livenessProbe.successThreshold | int | `1` | Success threshold for livenessProbe. |
 | langfuse.web.livenessProbe.timeoutSeconds | int | `5` | Timeout seconds for livenessProbe. |
 | langfuse.web.pod.additionalEnv | list | `[]` | List of additional environment variables to be added to all langfuse web pods. See [documentation](https://langfuse.com/docs/deployment/self-host#configuring-environment-variables) for details. |
+| langfuse.web.pod.affinity | string | `nil` | Affinity for for the web pods. Overrides the global affinity |
 | langfuse.web.pod.annotations | object | `{}` | Annotations for the web pods |
 | langfuse.web.pod.extraContainers | list | `[]` | Allows additional containers to be added to all langfuse web pods |
 | langfuse.web.pod.labels | object | `{}` | Labels for the web pods |
+| langfuse.web.pod.nodeSelector | string | `nil` | Node selector for for the web pods. Overrides the global nodeSelector |
+| langfuse.web.pod.tolerations | string | `nil` | Tolerations for for the web pods. Overrides the global tolerations |
 | langfuse.web.pod.topologySpreadConstraints | string | `nil` | Topology spread constraints for the web pods. Overrides the global topologySpreadConstraints |
 | langfuse.web.readinessProbe.failureThreshold | int | `3` | Failure threshold for readinessProbe. |
 | langfuse.web.readinessProbe.initialDelaySeconds | int | `20` | Initial delay seconds for readinessProbe. |
@@ -175,9 +178,12 @@ Open source LLM engineering platform - LLM observability, metrics, evaluations, 
 | langfuse.worker.livenessProbe.successThreshold | int | `1` | Success threshold for livenessProbe. |
 | langfuse.worker.livenessProbe.timeoutSeconds | int | `5` | Timeout seconds for livenessProbe. |
 | langfuse.worker.pod.additionalEnv | list | `[]` | List of additional environment variables to be added to all langfuse worker pods. See [documentation](https://langfuse.com/docs/deployment/self-host#configuring-environment-variables) for details. |
+| langfuse.worker.pod.affinity | string | `nil` | Affinity for for the worker pods. Overrides the global affinity |
 | langfuse.worker.pod.annotations | object | `{}` | Annotations for the worker pods |
 | langfuse.worker.pod.extraContainers | list | `[]` | Allows additional containers to be added to all langfuse worker pods |
 | langfuse.worker.pod.labels | object | `{}` | Labels for the worker pods |
+| langfuse.worker.pod.nodeSelector | string | `nil` | Node selector for for the worker pods. Overrides the global nodeSelector |
+| langfuse.worker.pod.tolerations | string | `nil` | Tolerations for for the worker pods. Overrides the global tolerations |
 | langfuse.worker.pod.topologySpreadConstraints | string | `nil` | Topology spread constraints for the worker pods. Overrides the global topologySpreadConstraints |
 | langfuse.worker.replicas | string | `nil` | Number of replicas to use if HPA is not enabled. Defaults to the global replicas |
 | langfuse.worker.resources | object | `{}` | Resources for the langfuse worker pods. Defaults to the global resources |

--- a/charts/langfuse/README.md
+++ b/charts/langfuse/README.md
@@ -130,12 +130,12 @@ Open source LLM engineering platform - LLM observability, metrics, evaluations, 
 | langfuse.web.pdb.maxUnavailable | string | `""` | Maximum number of unavailable pods during disruptions. Cannot be set simultaneously with minAvailable. Defaults to 1 if neither is set. |
 | langfuse.web.pdb.minAvailable | string | `""` | Minimum number of available pods during disruptions. Cannot be set simultaneously with maxUnavailable. |
 | langfuse.web.pod.additionalEnv | list | `[]` | List of additional environment variables to be added to all langfuse web pods. See [documentation](https://langfuse.com/docs/deployment/self-host#configuring-environment-variables) for details. |
-| langfuse.web.pod.affinity | string | `nil` | Affinity for for the web pods. Overrides the global affinity |
+| langfuse.web.pod.affinity | string | `nil` | Affinity for the web pods. Overrides the global affinity |
 | langfuse.web.pod.annotations | object | `{}` | Annotations for the web pods |
 | langfuse.web.pod.extraContainers | list | `[]` | Allows additional containers to be added to all langfuse web pods |
 | langfuse.web.pod.labels | object | `{}` | Labels for the web pods |
-| langfuse.web.pod.nodeSelector | string | `nil` | Node selector for for the web pods. Overrides the global nodeSelector |
-| langfuse.web.pod.tolerations | string | `nil` | Tolerations for for the web pods. Overrides the global tolerations |
+| langfuse.web.pod.nodeSelector | string | `nil` | Node selector for the web pods. Overrides the global nodeSelector |
+| langfuse.web.pod.tolerations | string | `nil` | Tolerations for the web pods. Overrides the global tolerations |
 | langfuse.web.pod.topologySpreadConstraints | string | `nil` | Topology spread constraints for the web pods. Overrides the global topologySpreadConstraints |
 | langfuse.web.readinessProbe.failureThreshold | int | `3` | Failure threshold for readinessProbe. |
 | langfuse.web.readinessProbe.initialDelaySeconds | int | `20` | Initial delay seconds for readinessProbe. |
@@ -185,12 +185,12 @@ Open source LLM engineering platform - LLM observability, metrics, evaluations, 
 | langfuse.worker.pdb.maxUnavailable | string | `""` | Maximum number of unavailable pods during disruptions. Cannot be set simultaneously with minAvailable. Defaults to 1 if neither is set. |
 | langfuse.worker.pdb.minAvailable | string | `""` | Minimum number of available pods during disruptions. Cannot be set simultaneously with maxUnavailable. |
 | langfuse.worker.pod.additionalEnv | list | `[]` | List of additional environment variables to be added to all langfuse worker pods. See [documentation](https://langfuse.com/docs/deployment/self-host#configuring-environment-variables) for details. |
-| langfuse.worker.pod.affinity | string | `nil` | Affinity for for the worker pods. Overrides the global affinity |
+| langfuse.worker.pod.affinity | string | `nil` | Affinity for the worker pods. Overrides the global affinity |
 | langfuse.worker.pod.annotations | object | `{}` | Annotations for the worker pods |
 | langfuse.worker.pod.extraContainers | list | `[]` | Allows additional containers to be added to all langfuse worker pods |
 | langfuse.worker.pod.labels | object | `{}` | Labels for the worker pods |
-| langfuse.worker.pod.nodeSelector | string | `nil` | Node selector for for the worker pods. Overrides the global nodeSelector |
-| langfuse.worker.pod.tolerations | string | `nil` | Tolerations for for the worker pods. Overrides the global tolerations |
+| langfuse.worker.pod.nodeSelector | string | `nil` | Node selector for the worker pods. Overrides the global nodeSelector |
+| langfuse.worker.pod.tolerations | string | `nil` | Tolerations for the worker pods. Overrides the global tolerations |
 | langfuse.worker.pod.topologySpreadConstraints | string | `nil` | Topology spread constraints for the worker pods. Overrides the global topologySpreadConstraints |
 | langfuse.worker.replicas | string | `nil` | Number of replicas to use if HPA is not enabled. Defaults to the global replicas |
 | langfuse.worker.resources | object | `{}` | Resources for the langfuse worker pods. Defaults to the global resources |

--- a/charts/langfuse/templates/web/deployment.yaml
+++ b/charts/langfuse/templates/web/deployment.yaml
@@ -115,15 +115,15 @@ spec:
           volumeMounts:
             {{- toYaml .Values.langfuse.extraVolumeMounts | nindent 12 }}
           {{- end }}
-      {{- with .Values.langfuse.nodeSelector }}
+      {{- with (coalesce .Values.langfuse.web.pod.nodeSelector .Values.langfuse.nodeSelector) }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.langfuse.affinity }}
+      {{- with (coalesce .Values.langfuse.web.pod.affinity .Values.langfuse.affinity) }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.langfuse.tolerations }}
+      {{- with (coalesce .Values.langfuse.web.pod.tolerations .Values.langfuse.tolerations) }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/langfuse/templates/worker/deployment.yaml
+++ b/charts/langfuse/templates/worker/deployment.yaml
@@ -96,15 +96,15 @@ spec:
           volumeMounts:
             {{- toYaml .Values.langfuse.extraVolumeMounts | nindent 12 }}
           {{- end }}
-      {{- with .Values.langfuse.nodeSelector }}
+      {{- with (coalesce .Values.langfuse.worker.pod.nodeSelector .Values.langfuse.nodeSelector) }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.langfuse.affinity }}
+      {{- with (coalesce .Values.langfuse.worker.pod.affinity .Values.langfuse.affinity) }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.langfuse.tolerations }}
+      {{- with (coalesce .Values.langfuse.worker.pod.tolerations .Values.langfuse.tolerations) }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/langfuse/values.yaml
+++ b/charts/langfuse/values.yaml
@@ -182,6 +182,12 @@ langfuse:
       annotations: {}
       # -- Labels for the web pods
       labels: {}
+      # -- Node selector for for the web pods. Overrides the global nodeSelector
+      nodeSelector: null
+      # -- Tolerations for for the web pods. Overrides the global tolerations
+      tolerations: null
+      # -- Affinity for for the web pods. Overrides the global affinity
+      affinity: null
       # -- Topology spread constraints for the web pods. Overrides the global topologySpreadConstraints
       topologySpreadConstraints: null
       # -- Allows additional containers to be added to all langfuse web pods
@@ -311,6 +317,12 @@ langfuse:
       annotations: {}
       # -- Labels for the worker pods
       labels: {}
+      # -- Node selector for for the worker pods. Overrides the global nodeSelector
+      nodeSelector: null
+      # -- Tolerations for for the worker pods. Overrides the global tolerations
+      tolerations: null
+      # -- Affinity for for the worker pods. Overrides the global affinity
+      affinity: null
       # -- Topology spread constraints for the worker pods. Overrides the global topologySpreadConstraints
       topologySpreadConstraints: null
       # -- Allows additional containers to be added to all langfuse worker pods

--- a/charts/langfuse/values.yaml
+++ b/charts/langfuse/values.yaml
@@ -184,11 +184,11 @@ langfuse:
       annotations: {}
       # -- Labels for the web pods
       labels: {}
-      # -- Node selector for for the web pods. Overrides the global nodeSelector
+      # -- Node selector for the web pods. Overrides the global nodeSelector
       nodeSelector: null
-      # -- Tolerations for for the web pods. Overrides the global tolerations
+      # -- Tolerations for the web pods. Overrides the global tolerations
       tolerations: null
-      # -- Affinity for for the web pods. Overrides the global affinity
+      # -- Affinity for the web pods. Overrides the global affinity
       affinity: null
       # -- Topology spread constraints for the web pods. Overrides the global topologySpreadConstraints
       topologySpreadConstraints: null
@@ -328,11 +328,11 @@ langfuse:
       annotations: {}
       # -- Labels for the worker pods
       labels: {}
-      # -- Node selector for for the worker pods. Overrides the global nodeSelector
+      # -- Node selector for the worker pods. Overrides the global nodeSelector
       nodeSelector: null
-      # -- Tolerations for for the worker pods. Overrides the global tolerations
+      # -- Tolerations for the worker pods. Overrides the global tolerations
       tolerations: null
-      # -- Affinity for for the worker pods. Overrides the global affinity
+      # -- Affinity for the worker pods. Overrides the global affinity
       affinity: null
       # -- Topology spread constraints for the worker pods. Overrides the global topologySpreadConstraints
       topologySpreadConstraints: null


### PR DESCRIPTION
This PR adds the ability to override the affinity, nodeSelector, and tolerations settings on a per web/worker deployment basis ( #322).

