### PR TITLE
feat: add pod disruption budgets for web and workers

### DIFF
--- a/charts/langfuse/README.md
+++ b/charts/langfuse/README.md
@@ -125,6 +125,9 @@ Open source LLM engineering platform - LLM observability, metrics, evaluations, 
 | langfuse.web.livenessProbe.periodSeconds | int | `10` | Period seconds for livenessProbe. |
 | langfuse.web.livenessProbe.successThreshold | int | `1` | Success threshold for livenessProbe. |
 | langfuse.web.livenessProbe.timeoutSeconds | int | `5` | Timeout seconds for livenessProbe. |
+| langfuse.web.pdb.create | bool | `true` | Set to `true` to create a Pod Disruption Budget for the langfuse web pods |
+| langfuse.web.pdb.maxUnavailable | string | `""` | Maximum number of unavailable pods during disruptions. Cannot be set simultaneously with minAvailable. Defaults to 1 if neither is set. |
+| langfuse.web.pdb.minAvailable | string | `""` | Minimum number of available pods during disruptions. Cannot be set simultaneously with maxUnavailable. |
 | langfuse.web.pod.additionalEnv | list | `[]` | List of additional environment variables to be added to all langfuse web pods. See [documentation](https://langfuse.com/docs/deployment/self-host#configuring-environment-variables) for details. |
 | langfuse.web.pod.annotations | object | `{}` | Annotations for the web pods |
 | langfuse.web.pod.extraContainers | list | `[]` | Allows additional containers to be added to all langfuse web pods |
@@ -174,6 +177,9 @@ Open source LLM engineering platform - LLM observability, metrics, evaluations, 
 | langfuse.worker.livenessProbe.periodSeconds | int | `10` | Period seconds for livenessProbe. |
 | langfuse.worker.livenessProbe.successThreshold | int | `1` | Success threshold for livenessProbe. |
 | langfuse.worker.livenessProbe.timeoutSeconds | int | `5` | Timeout seconds for livenessProbe. |
+| langfuse.worker.pdb.create | bool | `true` | Set to `true` to create a Pod Disruption Budget for the worker deployment |
+| langfuse.worker.pdb.maxUnavailable | string | `""` | Maximum number of unavailable pods during disruptions. Cannot be set simultaneously with minAvailable. Defaults to 1 if neither is set. |
+| langfuse.worker.pdb.minAvailable | string | `""` | Minimum number of available pods during disruptions. Cannot be set simultaneously with maxUnavailable. |
 | langfuse.worker.pod.additionalEnv | list | `[]` | List of additional environment variables to be added to all langfuse worker pods. See [documentation](https://langfuse.com/docs/deployment/self-host#configuring-environment-variables) for details. |
 | langfuse.worker.pod.annotations | object | `{}` | Annotations for the worker pods |
 | langfuse.worker.pod.extraContainers | list | `[]` | Allows additional containers to be added to all langfuse worker pods |

--- a/charts/langfuse/templates/validations.yaml
+++ b/charts/langfuse/templates/validations.yaml
@@ -248,3 +248,22 @@
 {{- if and $.Values.langfuse.worker.keda.enabled (or $.Values.langfuse.worker.hpa.enabled $.Values.langfuse.worker.vpa.enabled) -}}
     {{- fail "If keda is enabled for worker component, you cannot enable hpa or vpa. Please disable either keda or both hpa and vpa." -}}
 {{- end -}}
+
+# Validate Pod Disruption Budget settings
+{{- $webPdb := default dict $.Values.langfuse.web.pdb -}}
+{{- $webMinAvailable := get $webPdb "minAvailable" -}}
+{{- $webMaxUnavailable := get $webPdb "maxUnavailable" -}}
+{{- $webMinAvailableSet := and (hasKey $webPdb "minAvailable") (ne (toString $webMinAvailable) "") (ne (printf "%v" $webMinAvailable) "<nil>") -}}
+{{- $webMaxUnavailableSet := and (hasKey $webPdb "maxUnavailable") (ne (toString $webMaxUnavailable) "") (ne (printf "%v" $webMaxUnavailable) "<nil>") -}}
+{{- if and $webPdb.create $webMinAvailableSet $webMaxUnavailableSet -}}
+    {{- fail "Pod Disruption Budget for web component cannot have both minAvailable and maxUnavailable values" -}}
+{{- end -}}
+
+{{- $workerPdb := default dict $.Values.langfuse.worker.pdb -}}
+{{- $workerMinAvailable := get $workerPdb "minAvailable" -}}
+{{- $workerMaxUnavailable := get $workerPdb "maxUnavailable" -}}
+{{- $workerMinAvailableSet := and (hasKey $workerPdb "minAvailable") (ne (toString $workerMinAvailable) "") (ne (printf "%v" $workerMinAvailable) "<nil>") -}}
+{{- $workerMaxUnavailableSet := and (hasKey $workerPdb "maxUnavailable") (ne (toString $workerMaxUnavailable) "") (ne (printf "%v" $workerMaxUnavailable) "<nil>") -}}
+{{- if and $workerPdb.create $workerMinAvailableSet $workerMaxUnavailableSet -}}
+    {{- fail "Pod Disruption Budget for worker component cannot have both minAvailable and maxUnavailable values" -}}
+{{- end -}}

--- a/charts/langfuse/templates/web/deployment.yaml
+++ b/charts/langfuse/templates/web/deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "langfuse.labels" . | nindent 4 }}
+    app.kubernetes.io/component: web
     {{- with .Values.langfuse.web.deployment.additionalLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -34,6 +35,7 @@ spec:
       {{- end }}
       labels:
         {{- include "langfuse.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: web
         app: web
         {{- $podLabels := merge (.Values.langfuse.web.pod.labels | default dict) (.Values.langfuse.pod.labels | default dict) }}
         {{- with $podLabels }}

--- a/charts/langfuse/templates/web/pdb.yaml
+++ b/charts/langfuse/templates/web/pdb.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.langfuse.web.pdb.create }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "langfuse.fullname" . }}-web-pdb
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "langfuse.labels" . | nindent 4 }}
+  {{- with (coalesce .Values.langfuse.web.deployment.annotations .Values.langfuse.deployment.annotations) }}
+  annotations:
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- if .Values.langfuse.web.pdb.minAvailable }}
+  minAvailable: {{ .Values.langfuse.web.pdb.minAvailable }}
+  {{- end  }}
+  {{- if or .Values.langfuse.web.pdb.maxUnavailable (not .Values.langfuse.web.pdb.minAvailable) }}
+  maxUnavailable: {{ .Values.langfuse.web.pdb.maxUnavailable | default 1 }}
+  {{- end  }}
+  selector:
+    matchLabels:
+      {{- include "langfuse.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: web
+{{- end }}

--- a/charts/langfuse/templates/worker/deployment.yaml
+++ b/charts/langfuse/templates/worker/deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "langfuse.labels" . | nindent 4 }}
+    app.kubernetes.io/component: worker
     {{- with .Values.langfuse.worker.deployment.additionalLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -34,6 +35,7 @@ spec:
       {{- end }}
       labels:
         {{- include "langfuse.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: worker
         app: worker
         {{- $podLabels := merge (.Values.langfuse.worker.pod.labels | default dict) (.Values.langfuse.pod.labels | default dict) }}
         {{- with $podLabels }}

--- a/charts/langfuse/templates/worker/pdb.yaml
+++ b/charts/langfuse/templates/worker/pdb.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.langfuse.worker.pdb.create }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "langfuse.fullname" . }}-worker-pdb
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "langfuse.labels" . | nindent 4 }}
+  {{- with (coalesce .Values.langfuse.worker.deployment.annotations .Values.langfuse.deployment.annotations) }}
+  annotations:
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- if .Values.langfuse.worker.pdb.minAvailable }}
+  minAvailable: {{ .Values.langfuse.worker.pdb.minAvailable }}
+  {{- end  }}
+  {{- if or .Values.langfuse.worker.pdb.maxUnavailable (not .Values.langfuse.worker.pdb.minAvailable) }}
+  maxUnavailable: {{ .Values.langfuse.worker.pdb.maxUnavailable | default 1 }}
+  {{- end  }}
+  selector:
+    matchLabels:
+      {{- include "langfuse.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: worker
+{{- end }}

--- a/charts/langfuse/tests/basic_test.yaml
+++ b/charts/langfuse/tests/basic_test.yaml
@@ -4,6 +4,7 @@ templates:
   - worker/deployment.yaml
   - web/service.yaml
   - serviceaccount.yaml
+  - web/pdb.yaml
 tests:
   - it: should render with default values
     values:
@@ -97,3 +98,15 @@ tests:
             name: HOSTNAME
             value: "127.0.0.1"
         template: worker/deployment.yaml
+
+  - it: should create a web PDB with 2 maxUnavailable when specified
+    values:
+      - ../values.lint.yaml
+      - values/pdb.yaml
+    set:
+      langfuse.image.tag: "v1.2.3"
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: 2
+        template: web/pdb.yaml

--- a/charts/langfuse/tests/values/pdb.yaml
+++ b/charts/langfuse/tests/values/pdb.yaml
@@ -1,0 +1,4 @@
+langfuse:
+  web:
+    pdb:
+      maxUnavailable: 2

--- a/charts/langfuse/values.yaml
+++ b/charts/langfuse/values.yaml
@@ -288,6 +288,15 @@ langfuse:
       # -- Success threshold for readinessProbe.
       successThreshold: 1
 
+    # Pod Disruption Budget configuration for the web deployment
+    pdb:
+      # -- Set to `true` to create a Pod Disruption Budget for the langfuse web pods
+      create: true
+      # -- Minimum number of available pods during disruptions. Cannot be set simultaneously with maxUnavailable.
+      minAvailable: ""
+      # -- Maximum number of unavailable pods during disruptions. Cannot be set simultaneously with minAvailable. Defaults to 1 if neither is set.
+      maxUnavailable: ""
+
   # Worker deployment configuration
   worker:
     image:
@@ -372,6 +381,15 @@ langfuse:
       updatePolicy:
         # -- The update policy mode for the langfuse worker pods
         updateMode: Auto
+
+    # Pod Disruption Budget configuration for the worker deployment
+    pdb:
+      # -- Set to `true` to create a Pod Disruption Budget for the worker deployment
+      create: true
+      # -- Minimum number of available pods during disruptions. Cannot be set simultaneously with maxUnavailable.
+      minAvailable: ""
+      # -- Maximum number of unavailable pods during disruptions. Cannot be set simultaneously with minAvailable. Defaults to 1 if neither is set.
+      maxUnavailable: ""
 
     livenessProbe:
       # -- Initial delay seconds for livenessProbe.


### PR DESCRIPTION
Adds pod disruption budgets for web and worker pods with a max unavailable count of 1 by default.

Fixes #324