### PR TITLE
fix: add explicit permissions to workflow files

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
+
 jobs:
   unit-tests:
     name: Run Helm Unit Tests

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -3,6 +3,10 @@ on:
   pull_request:
     paths:
       - 'charts/**'
+
+permissions:
+  contents: read
+
 jobs:
   validate:
     name: Validate Helm Chart


### PR DESCRIPTION
## Summary
- Add explicit `permissions` blocks to `test.yaml` and `validate.yaml` workflows to resolve GitHub code scanning alerts (#3, #4)
- `test.yaml`: `contents: read`, `checks: write`, `pull-requests: write` (needed for publish-unit-test-result-action)
- `validate.yaml`: `contents: read`

## Test plan
- [ ] Verify test workflow still posts unit test results on PRs
- [ ] Verify validate workflow still runs helm lint and helm-docs check

🤖 Generated with [Claude Code](https://claude.com/claude-code)