### PR TITLE
feat: add OpenShift / OKD support (Route template + deployment guide)

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -2,6 +2,64 @@
 
 In this guide, we collect common issues and solution approaches to address problems you might encounter while the Langfuse Helm chart.
 
+## OpenShift / OKD: Bitnami pods fail due to Security Context Constraints (SCC)
+
+### Symptom
+
+Pods for the bundled PostgreSQL or Valkey/Redis sub-charts are stuck in
+`CreateContainerConfigError` or `CrashLoopBackOff` with an error similar to:
+
+```
+Error: container has runAsNonRoot and image will run as root
+```
+
+or
+
+```
+unable to validate against any security context constraint: [spec.containers[0].securityContext.runAsUser: Invalid value: 1001: must be in the ranges: [1000700000, 1000799999]]
+```
+
+### Why it happens
+
+Bitnami images are built to run as a fixed UID (`1001`). OpenShift's default
+`restricted-v2` SCC enforces a namespace-allocated UID range and rejects
+fixed UIDs that fall outside that range.
+
+### Fix A — Grant `anyuid` SCC (dev/demo clusters)
+
+```bash
+oc adm policy add-scc-to-user anyuid \
+  -z <release-name> \
+  -n <namespace>
+```
+
+Replace `<release-name>` with your Helm release name (the service account
+has the same name by default).
+
+### Fix B — Use an external PostgreSQL (recommended for production)
+
+Provision PostgreSQL via the [CrunchyData PGO operator][pgo] or a managed
+service and disable the bundled sub-chart:
+
+```yaml
+postgresql:
+  deploy: false
+  host: <external-postgres-host>
+  auth:
+    username: langfuse
+    existingSecret: langfuse
+    secretKeys:
+      userPasswordKey: postgresql-password
+```
+
+This removes the Bitnami dependency entirely and eliminates the SCC issue
+for the database pod.
+
+See the full [OpenShift deployment example](examples/openshift/README.md) for
+step-by-step instructions.
+
+[pgo]: https://access.crunchydata.com/documentation/postgres-operator/latest/
+
 ## Invalid ClickHouse Password - Avoid special characters
 
 If you encounter an error like

--- a/charts/langfuse/templates/route.yaml
+++ b/charts/langfuse/templates/route.yaml
@@ -1,0 +1,48 @@
+{{- if .Values.langfuse.route.enabled -}}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ include "langfuse.fullname" . }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "langfuse.labels" . | nindent 4 }}
+    {{- with .Values.langfuse.route.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.langfuse.route.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.langfuse.route.host }}
+  host: {{ .Values.langfuse.route.host | quote }}
+  {{- end }}
+  to:
+    kind: Service
+    name: {{ include "langfuse.fullname" . }}-web
+    weight: 100
+  port:
+    targetPort: http
+  {{- if .Values.langfuse.route.tls.enabled }}
+  tls:
+    termination: {{ .Values.langfuse.route.tls.termination }}
+    insecureEdgeTerminationPolicy: {{ .Values.langfuse.route.tls.insecureEdgeTerminationPolicy }}
+    {{- if .Values.langfuse.route.tls.certificate }}
+    certificate: |
+      {{- .Values.langfuse.route.tls.certificate | nindent 6 }}
+    {{- end }}
+    {{- if .Values.langfuse.route.tls.key }}
+    key: |
+      {{- .Values.langfuse.route.tls.key | nindent 6 }}
+    {{- end }}
+    {{- if .Values.langfuse.route.tls.caCertificate }}
+    caCertificate: |
+      {{- .Values.langfuse.route.tls.caCertificate | nindent 6 }}
+    {{- end }}
+    {{- if .Values.langfuse.route.tls.destinationCACertificate }}
+    destinationCACertificate: |
+      {{- .Values.langfuse.route.tls.destinationCACertificate | nindent 6 }}
+    {{- end }}
+  {{- end }}
+  wildcardPolicy: None
+{{- end }}

--- a/charts/langfuse/tests/route_test.yaml
+++ b/charts/langfuse/tests/route_test.yaml
@@ -1,0 +1,129 @@
+suite: test OpenShift Route functionality
+templates:
+  - route.yaml
+tests:
+  - it: should not render route when disabled (default)
+    values:
+      - ../values.lint.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+        template: route.yaml
+
+  - it: should render route with auto-generated host
+    values:
+      - ../values.lint.yaml
+    set:
+      langfuse.route.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+        template: route.yaml
+      - isKind:
+          of: Route
+        template: route.yaml
+      - equal:
+          path: spec.to.kind
+          value: Service
+        template: route.yaml
+      - equal:
+          path: spec.to.name
+          value: RELEASE-NAME-langfuse-web
+        template: route.yaml
+      - equal:
+          path: spec.port.targetPort
+          value: http
+        template: route.yaml
+      - isNull:
+          path: spec.host
+        template: route.yaml
+
+  - it: should render route with explicit host
+    values:
+      - ../values.lint.yaml
+    set:
+      langfuse.route.enabled: true
+      langfuse.route.host: langfuse.apps.cluster.example.com
+    asserts:
+      - equal:
+          path: spec.host
+          value: langfuse.apps.cluster.example.com
+        template: route.yaml
+
+  - it: should render TLS edge termination by default when route enabled
+    values:
+      - ../values.lint.yaml
+    set:
+      langfuse.route.enabled: true
+    asserts:
+      - equal:
+          path: spec.tls.termination
+          value: edge
+        template: route.yaml
+      - equal:
+          path: spec.tls.insecureEdgeTerminationPolicy
+          value: Redirect
+        template: route.yaml
+
+  - it: should render route with passthrough TLS
+    values:
+      - ../values.lint.yaml
+    set:
+      langfuse.route.enabled: true
+      langfuse.route.tls.termination: passthrough
+      langfuse.route.tls.insecureEdgeTerminationPolicy: None
+    asserts:
+      - equal:
+          path: spec.tls.termination
+          value: passthrough
+        template: route.yaml
+      - equal:
+          path: spec.tls.insecureEdgeTerminationPolicy
+          value: None
+        template: route.yaml
+
+  - it: should render route without TLS when disabled
+    values:
+      - ../values.lint.yaml
+    set:
+      langfuse.route.enabled: true
+      langfuse.route.tls.enabled: false
+    asserts:
+      - isNull:
+          path: spec.tls
+        template: route.yaml
+
+  - it: should render route with custom annotations and labels
+    values:
+      - ../values.lint.yaml
+    set:
+      langfuse.route.enabled: true
+      langfuse.route.annotations:
+        haproxy.router.openshift.io/timeout: 60s
+      langfuse.route.additionalLabels:
+        environment: staging
+    asserts:
+      - equal:
+          path: metadata.annotations["haproxy.router.openshift.io/timeout"]
+          value: 60s
+        template: route.yaml
+      - equal:
+          path: metadata.labels.environment
+          value: staging
+        template: route.yaml
+
+  - it: should not render route when ingress is used instead
+    values:
+      - ../values.lint.yaml
+    set:
+      langfuse.route.enabled: false
+      langfuse.ingress.enabled: true
+      langfuse.ingress.hosts:
+        - host: langfuse.example.com
+          paths:
+            - path: /
+              pathType: Prefix
+    asserts:
+      - hasDocuments:
+          count: 0
+        template: route.yaml

--- a/charts/langfuse/values.yaml
+++ b/charts/langfuse/values.yaml
@@ -114,6 +114,37 @@ langfuse:
       # -- The name of the secret to use for TLS Key
       secretName: ""
 
+  # OpenShift Route (alternative to ingress for OpenShift / OKD clusters)
+  # Requires the `route.openshift.io/v1` API to be available on the cluster.
+  # Do not enable both `ingress` and `route` at the same time.
+  route:
+    # -- Set to `true` to create an OpenShift Route instead of an Ingress resource
+    enabled: false
+    # -- Hostname for the route. When empty, OpenShift auto-generates one based on the cluster wildcard domain.
+    host: ""
+    # -- Additional labels for the route resource
+    additionalLabels: {}
+    # -- Annotations for the route resource
+    annotations: {}
+    tls:
+      # -- Set to `true` to configure TLS on the route
+      enabled: true
+      # -- TLS termination type: `edge`, `passthrough`, or `reencrypt`
+      # edge:        TLS terminates at the router; traffic to the pod is plain HTTP
+      # reencrypt:   TLS terminates at the router and is re-encrypted toward the pod
+      # passthrough: TLS passes through unchanged to the pod (no cert needed here)
+      termination: edge
+      # -- What to do with insecure (HTTP) traffic: `Redirect`, `Allow`, or `None`
+      insecureEdgeTerminationPolicy: Redirect
+      # -- PEM-encoded TLS certificate. Leave empty to use the cluster default wildcard certificate.
+      certificate: ""
+      # -- PEM-encoded TLS private key. Required when `certificate` is set.
+      key: ""
+      # -- PEM-encoded CA certificate (required for `reencrypt` termination)
+      caCertificate: ""
+      # -- PEM-encoded destination CA certificate (required for `reencrypt` termination)
+      destinationCACertificate: ""
+
   # -- Pod security context for all langfuse deployments
   podSecurityContext: {}
   # -- Security context for all langfuse deployments

--- a/examples/openshift/README.md
+++ b/examples/openshift/README.md
@@ -1,0 +1,120 @@
+# Langfuse on OpenShift / OKD
+
+This example deploys Langfuse on an OpenShift or OKD cluster using an
+OpenShift **Route** for ingress and documents the Security Context Constraint
+(SCC) adjustments required by the bundled Bitnami sub-charts.
+
+## What is different from plain Kubernetes
+
+| Area | Plain Kubernetes | OpenShift |
+|---|---|---|
+| Ingress | `Ingress` resource | `Route` resource (`route.openshift.io/v1`) |
+| TLS | Cert-Manager or manual secret | Router handles TLS via cluster wildcard cert |
+| Pod UIDs | Unrestricted | `restricted-v2` SCC: random UID from namespace range |
+| Bitnami images | Work out of the box | Require `anyuid` SCC or external DB (see below) |
+
+## Prerequisites
+
+### 1. Create the OpenShift project
+
+```bash
+oc new-project langfuse
+```
+
+### 2. Find your cluster wildcard domain
+
+```bash
+oc get ingresses.config.openshift.io cluster \
+  -o jsonpath='{.spec.domain}'
+# e.g. apps.my-cluster.example.com
+```
+
+### 3. Create the secret
+
+Edit `secret.yaml` — replace all `<CHANGE_ME>` placeholders — then apply:
+
+```bash
+# Generate values
+SALT=$(openssl rand -base64 32)
+ENCRYPTION_KEY=$(openssl rand -hex 32)
+NEXTAUTH_SECRET=$(openssl rand -base64 32)
+PG_PASSWORD=$(openssl rand -base64 24)
+
+oc create secret generic langfuse \
+  --from-literal=salt="$SALT" \
+  --from-literal=encryption-key="$ENCRYPTION_KEY" \
+  --from-literal=nextauth-secret="$NEXTAUTH_SECRET" \
+  --from-literal=postgresql-password="$PG_PASSWORD" \
+  --from-literal=redis-password="$PG_PASSWORD" \
+  -n langfuse
+```
+
+### 4. Handle the Bitnami SCC requirement
+
+The bundled **PostgreSQL** and **Valkey/Redis** images from Bitnami run as
+UID `1001`. OpenShift's default `restricted-v2` SCC rejects fixed UIDs.
+
+**Option A — Grant `anyuid` (simplest, suitable for dev clusters):**
+
+```bash
+oc adm policy add-scc-to-user anyuid \
+  -z langfuse \
+  -n langfuse
+```
+
+**Option B — Use an external PostgreSQL (recommended for production):**
+
+Provision PostgreSQL via the [CrunchyData PGO operator][pgo] or any managed
+service, then set in `values.yaml`:
+
+```yaml
+postgresql:
+  deploy: false
+  host: my-postgres-host
+  auth:
+    username: langfuse
+    existingSecret: langfuse
+    secretKeys:
+      userPasswordKey: postgresql-password
+```
+
+This removes the Bitnami PostgreSQL dependency entirely and avoids the SCC
+issue for the database pod.
+
+[pgo]: https://access.crunchydata.com/documentation/postgres-operator/latest/
+
+## Install
+
+```bash
+helm repo add langfuse https://langfuse.github.io/langfuse-k8s
+helm repo update
+
+helm install langfuse langfuse/langfuse \
+  -n langfuse \
+  -f values.yaml
+```
+
+## Verify
+
+```bash
+# Watch pods come up
+oc get pods -n langfuse -w
+
+# Get the auto-generated Route URL
+oc get route langfuse -n langfuse -o jsonpath='{.spec.host}'
+```
+
+Open `https://<route-host>` in your browser, create an account, and generate
+your API keys under **Settings → API Keys**.
+
+## Update `NEXTAUTH_URL`
+
+After the Route is created, update `langfuse.nextauth.url` in `values.yaml`
+with the actual Route hostname and run `helm upgrade`:
+
+```bash
+helm upgrade langfuse langfuse/langfuse \
+  -n langfuse \
+  -f values.yaml \
+  --set langfuse.nextauth.url=https://$(oc get route langfuse -n langfuse -o jsonpath='{.spec.host}')
+```

--- a/examples/openshift/README.md
+++ b/examples/openshift/README.md
@@ -38,14 +38,17 @@ Edit `secret.yaml` — replace all `<CHANGE_ME>` placeholders — then apply:
 SALT=$(openssl rand -base64 32)
 ENCRYPTION_KEY=$(openssl rand -hex 32)
 NEXTAUTH_SECRET=$(openssl rand -base64 32)
-PG_PASSWORD=$(openssl rand -base64 24)
+# Use alphanumeric-only passwords — ClickHouse rejects passwords with special
+# characters such as %, @, :, &, # (see TROUBLESHOOTING.md)
+DB_PASSWORD=$(openssl rand -base64 24 | tr -dc 'a-zA-Z0-9' | head -c 24)
 
 oc create secret generic langfuse \
   --from-literal=salt="$SALT" \
   --from-literal=encryption-key="$ENCRYPTION_KEY" \
   --from-literal=nextauth-secret="$NEXTAUTH_SECRET" \
-  --from-literal=postgresql-password="$PG_PASSWORD" \
-  --from-literal=redis-password="$PG_PASSWORD" \
+  --from-literal=postgresql-password="$DB_PASSWORD" \
+  --from-literal=redis-password="$DB_PASSWORD" \
+  --from-literal=clickhouse-password="$DB_PASSWORD" \
   -n langfuse
 ```
 
@@ -56,11 +59,18 @@ UID `1001`. OpenShift's default `restricted-v2` SCC rejects fixed UIDs.
 
 **Option A — Grant `anyuid` (simplest, suitable for dev clusters):**
 
+The chart creates a `langfuse` service account for the web/worker/S3 pods.
+ClickHouse uses the `default` service account. Both need `anyuid`:
+
 ```bash
-oc adm policy add-scc-to-user anyuid \
-  -z langfuse \
-  -n langfuse
+oc adm policy add-scc-to-user anyuid -z langfuse  -n langfuse
+oc adm policy add-scc-to-user anyuid -z default   -n langfuse
 ```
+
+> **Note:** The Langfuse web/worker image uses a non-numeric user (`nextjs`).
+> Setting `podSecurityContext.runAsNonRoot: true` in `values.yaml` causes
+> `CreateContainerConfigError` because OpenShift cannot verify a named user is
+> non-root. Leave `podSecurityContext: {}` and rely on the `anyuid` grant instead.
 
 **Option B — Use an external PostgreSQL (recommended for production):**
 

--- a/examples/openshift/secret.yaml
+++ b/examples/openshift/secret.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: langfuse
+  namespace: <YOUR_NAMESPACE>
+type: Opaque
+stringData:
+  # Generate: openssl rand -base64 32
+  salt: "<CHANGE_ME>"
+  # Generate: openssl rand -hex 32
+  encryption-key: "<CHANGE_ME>"
+  # Generate: openssl rand -base64 32
+  nextauth-secret: "<CHANGE_ME>"
+  # PostgreSQL password
+  postgresql-password: "<CHANGE_ME>"

--- a/examples/openshift/secret.yaml
+++ b/examples/openshift/secret.yaml
@@ -11,5 +11,7 @@ stringData:
   encryption-key: "<CHANGE_ME>"
   # Generate: openssl rand -base64 32
   nextauth-secret: "<CHANGE_ME>"
-  # PostgreSQL password
+  # Shared password for PostgreSQL, Redis, and ClickHouse
   postgresql-password: "<CHANGE_ME>"
+  redis-password: "<CHANGE_ME>"
+  clickhouse-password: "<CHANGE_ME>"

--- a/examples/openshift/values.yaml
+++ b/examples/openshift/values.yaml
@@ -68,15 +68,12 @@ langfuse:
       termination: edge
       insecureEdgeTerminationPolicy: Redirect
 
-  # OpenShift's restricted-v2 SCC requires runAsNonRoot.
-  # The Langfuse web/worker containers (Next.js) run fine as non-root.
-  podSecurityContext:
-    runAsNonRoot: true
-  securityContext:
-    allowPrivilegeEscalation: false
-    capabilities:
-      drop:
-        - ALL
+  # ⚠️  Do NOT set runAsNonRoot: true here.
+  # The Langfuse web/worker image uses a non-numeric user ("nextjs") which
+  # OpenShift cannot verify as non-root, causing CreateContainerConfigError.
+  # Leave these empty — the anyuid SCC grant (see Prerequisites) is sufficient.
+  podSecurityContext: {}
+  securityContext: {}
 
 postgresql:
   deploy: true
@@ -101,6 +98,11 @@ postgresql:
       capabilities:
         drop:
           - ALL
+
+clickhouse:
+  auth:
+    existingSecret: langfuse
+    existingSecretKey: clickhouse-password
 
 redis:
   auth:

--- a/examples/openshift/values.yaml
+++ b/examples/openshift/values.yaml
@@ -1,0 +1,118 @@
+# Langfuse Helm values for OpenShift / OKD
+#
+# Key differences from a plain Kubernetes deployment:
+#   1. Use `route` instead of `ingress` — OpenShift's built-in router handles TLS.
+#   2. ⚠️  KNOWN LIMITATION — Bitnami sub-charts (PostgreSQL, Valkey/Redis) run as
+#      a fixed UID (1001) which conflicts with OpenShift's restricted-v2 SCC.
+#      Two options are documented below and in TROUBLESHOOTING.md:
+#        Option A (dev/demo): grant anyuid SCC to the service account
+#        Option B (production): use an external PostgreSQL — e.g. CrunchyData PGO
+#      operator or any managed service — and set `postgresql.deploy: false`.
+#      This is a limitation of the upstream Bitnami images, not the Langfuse chart.
+#   3. Secrets must be created before installing the chart (see secret.yaml).
+#
+# Prerequisites
+# -------------
+#   1. Create the namespace/project:
+#        oc new-project <YOUR_NAMESPACE>
+#   2. Generate and apply the secret:
+#        oc apply -f secret.yaml
+#   3. (Only if using bundled PostgreSQL/Redis) Grant the anyuid SCC to the
+#      chart's service account — required because Bitnami images run as UID 1001:
+#        oc adm policy add-scc-to-user anyuid \
+#          -z langfuse \
+#          -n <YOUR_NAMESPACE>
+#      For a production cluster consider using an external PostgreSQL (e.g. via the
+#      CrunchyData PGO operator) and setting `postgresql.deploy: false` to avoid
+#      the SCC requirement entirely.
+#
+# Install
+# -------
+#   helm install langfuse langfuse/langfuse \
+#     -n <YOUR_NAMESPACE> \
+#     -f values.yaml
+
+langfuse:
+  # Reference the pre-created secret for all sensitive values
+  encryptionKey:
+    secretKeyRef:
+      name: langfuse
+      key: encryption-key
+
+  salt:
+    secretKeyRef:
+      name: langfuse
+      key: salt
+
+  nextauth:
+    # OpenShift auto-generates the hostname from the Route below; set this to
+    # the final URL once the Route is created, or use the wildcard domain:
+    #   https://langfuse-<namespace>.apps.<cluster-domain>
+    url: "https://langfuse-<YOUR_NAMESPACE>.apps.<CLUSTER_DOMAIN>"
+    secret:
+      secretKeyRef:
+        name: langfuse
+        key: nextauth-secret
+
+  features:
+    telemetryEnabled: false
+
+  # Use OpenShift Route instead of Ingress
+  route:
+    enabled: true
+    # Leave host empty to let OpenShift auto-generate from the wildcard domain,
+    # or set explicitly: langfuse.apps.<cluster-domain>
+    host: ""
+    tls:
+      enabled: true
+      termination: edge
+      insecureEdgeTerminationPolicy: Redirect
+
+  # OpenShift's restricted-v2 SCC requires runAsNonRoot.
+  # The Langfuse web/worker containers (Next.js) run fine as non-root.
+  podSecurityContext:
+    runAsNonRoot: true
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+
+postgresql:
+  deploy: true
+  auth:
+    existingSecret: langfuse
+    secretKeys:
+      adminPasswordKey: postgresql-password
+      userPasswordKey: postgresql-password
+  # Bitnami PostgreSQL runs as UID 1001. OpenShift's restricted-v2 SCC will
+  # reject this unless you either grant anyuid (see Prerequisites above) or
+  # switch to an external PostgreSQL instance with `postgresql.deploy: false`.
+  primary:
+    podSecurityContext:
+      # Uncomment if you granted anyuid SCC:
+      # runAsUser: 1001
+      fsGroup: 1001
+    containerSecurityContext:
+      # Uncomment if you granted anyuid SCC:
+      # runAsUser: 1001
+      runAsNonRoot: true
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
+
+redis:
+  auth:
+    existingSecret: langfuse
+    existingSecretPasswordKey: redis-password
+  # Same SCC note as PostgreSQL above applies to Valkey/Redis.
+  master:
+    podSecurityContext:
+      fsGroup: 1001
+    containerSecurityContext:
+      runAsNonRoot: true
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL


### PR DESCRIPTION
## Summary

Adds support for deploying Langfuse on OpenShift / OKD clusters, which use `Route` resources instead of `Ingress` and enforce pod security via Security Context Constraints (SCCs).

## Changes

- **`charts/langfuse/templates/route.yaml`** — new `route.openshift.io/v1` Route template, disabled by default (`langfuse.route.enabled: false`), supports `edge`, `reencrypt`, and `passthrough` TLS termination
- **`charts/langfuse/values.yaml`** — new `langfuse.route` section (host, TLS options, annotations, labels)
- **`charts/langfuse/tests/route_test.yaml`** — 8 helm-unittest tests; all 69 existing tests still pass
- **`examples/openshift/`** — step-by-step README, annotated values.yaml, and secret template validated on OCP 4.20
- **`TROUBLESHOOTING.md`** — new section on Bitnami SCC conflict with two remediation paths

## Known Limitation — Bitnami sub-charts and OpenShift SCCs

Bitnami images (PostgreSQL, Redis, ClickHouse) run as fixed UID `1001`, which conflicts with OpenShift's `restricted-v2` SCC. Two options documented:

- **Option A (dev/demo):** grant `anyuid` SCC to the `langfuse` and `default` service accounts
- **Option B (production):** use an external PostgreSQL (`postgresql.deploy: false`) via CrunchyData PGO operator — eliminates the Bitnami dependency entirely

This is a limitation of the upstream Bitnami images, not the Langfuse chart itself.

## Test plan

- [x] All 69 existing + 8 new helm-unittest tests pass
- [x] End-to-end deployment validated on OpenShift 4.20 — all pods Running, Route accessible via HTTPS

Made with [Cursor](https://cursor.com)