### PR TITLE
ci: add zizmor for k8s

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -75,7 +75,7 @@ jobs:
           REPO_LOWER: ${{ steps.chart-version.outputs.repo_lower }}
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@a0d2dc62c5e491af8ef6ba64a2e02bcf3fb33aa1 # v1.7.0
+        uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           CR_GENERATE_RELEASE_NOTES: "true"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,19 +5,27 @@ on:
     branches:
       - main
     paths:
-      - 'charts/*/Chart.yaml'
+      - "charts/*/Chart.yaml"
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   release:
     name: Release Helm Chart
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      packages: write
+      contents: write # Create GitHub releases and update release artifacts.
+      packages: write # Push Helm charts to GitHub Container Registry.
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Configure Git
         run: |
@@ -25,7 +33,7 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
 
       - name: Update dependencies
         run: helm dependency update charts/langfuse/
@@ -37,7 +45,7 @@ jobs:
           CHART_DIR=$(find ./charts -name "Chart.yaml" -not -path "*/\.git/*" | head -1 | xargs dirname)
           CHART_NAME=$(yq e '.name' "$CHART_DIR/Chart.yaml")
           CHART_VERSION=$(yq e '.version' "$CHART_DIR/Chart.yaml")
-          REPO_LOWER=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
+          REPO_LOWER=$(echo "$GITHUB_REPOSITORY" | tr '[:upper:]' '[:lower:]')
           echo "chart_dir=$CHART_DIR" >> $GITHUB_OUTPUT
           echo "chart_name=$CHART_NAME" >> $GITHUB_OUTPUT
           echo "chart_version=$CHART_VERSION" >> $GITHUB_OUTPUT
@@ -45,7 +53,7 @@ jobs:
           echo "Chart: $CHART_NAME:$CHART_VERSION in $CHART_DIR"
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -53,14 +61,21 @@ jobs:
 
       - name: Package Helm Chart
         run: |
-          helm package ${{ steps.chart-version.outputs.chart_dir }} --version ${{ steps.chart-version.outputs.chart_version }}
+          helm package "$CHART_DIR" --version "$CHART_VERSION"
+        env:
+          CHART_DIR: ${{ steps.chart-version.outputs.chart_dir }}
+          CHART_VERSION: ${{ steps.chart-version.outputs.chart_version }}
 
       - name: Push to GitHub Container Registry
         run: |
-          helm push ${{ steps.chart-version.outputs.chart_name }}-${{ steps.chart-version.outputs.chart_version }}.tgz oci://ghcr.io/${{ steps.chart-version.outputs.repo_lower }}/charts
+          helm push "${CHART_NAME}-${CHART_VERSION}.tgz" "oci://ghcr.io/${REPO_LOWER}/charts"
+        env:
+          CHART_NAME: ${{ steps.chart-version.outputs.chart_name }}
+          CHART_VERSION: ${{ steps.chart-version.outputs.chart_version }}
+          REPO_LOWER: ${{ steps.chart-version.outputs.repo_lower }}
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.7.0
+        uses: helm/chart-releaser-action@a0d2dc62c5e491af8ef6ba64a2e02bcf3fb33aa1 # v1.7.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           CR_GENERATE_RELEASE_NOTES: "true"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,23 +5,29 @@ on:
     branches:
       - main
 
-permissions:
-  contents: read
-  checks: write
-  pull-requests: write
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   unit-tests:
     name: Run Helm Unit Tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # Read repository contents for checkout.
+      checks: write # Publish unit test check results.
+      pull-requests: write # Comment with unit test results on pull requests.
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
         with:
           version: v3.13.2
 
@@ -37,7 +43,7 @@ jobs:
           helm unittest charts/langfuse/ --color --output-type JUnit --output-file test-results.xml
 
       - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@c950f6fb443cb5af20a377fd0dfaa78838901040 # v2.23.0
         if: always()
         with:
           files: test-results.xml

--- a/.github/workflows/update-langfuse-version.yml
+++ b/.github/workflows/update-langfuse-version.yml
@@ -1,21 +1,29 @@
 name: Update Langfuse Version
 on:
   schedule:
-    - cron: '0 9 * * 1'  # Run every Monday at 9 AM UTC
-  workflow_dispatch:  # Allow manual triggering
+    - cron: "0 9 * * 1" # Run every Monday at 9 AM UTC
+  workflow_dispatch: # Allow manual triggering
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   check-and-update:
+    name: Check and update Langfuse version
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
-    
+      contents: write # Commit generated chart and documentation updates.
+      pull-requests: write # Open the automated Langfuse update pull request.
+
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
 
       - name: Get current Langfuse version
         id: current-version
@@ -34,19 +42,22 @@ jobs:
       - name: Compare versions
         id: version-check
         run: |
-          if [ "${{ steps.current-version.outputs.current }}" != "${{ steps.latest-version.outputs.latest }}" ]; then
+          if [ "$CURRENT_VERSION" != "$LATEST_VERSION" ]; then
             echo "needs_update=true" >> $GITHUB_OUTPUT
-            echo "New version available: ${{ steps.latest-version.outputs.latest }}"
+            echo "New version available: $LATEST_VERSION"
           else
             echo "needs_update=false" >> $GITHUB_OUTPUT
             echo "Already up to date"
           fi
+        env:
+          CURRENT_VERSION: ${{ steps.current-version.outputs.current }}
+          LATEST_VERSION: ${{ steps.latest-version.outputs.latest }}
 
       - name: Setup Node.js
         if: steps.version-check.outputs.needs_update == 'true'
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '24'
+          node-version: "24"
 
       - name: Install semver
         if: steps.version-check.outputs.needs_update == 'true'
@@ -59,16 +70,18 @@ jobs:
           # Get current chart version
           CURRENT_CHART_VERSION=$(grep '^version:' charts/langfuse/Chart.yaml | cut -d ' ' -f 2)
           echo "Current chart version: $CURRENT_CHART_VERSION"
-          
+
           # Increment patch version
           NEW_CHART_VERSION=$(semver -i patch $CURRENT_CHART_VERSION)
           echo "New chart version: $NEW_CHART_VERSION"
-          
+
           # Update Chart.yaml
           sed -i "s/^version: .*/version: $NEW_CHART_VERSION/" charts/langfuse/Chart.yaml
-          sed -i "s/^appVersion: .*/appVersion: \"${{ steps.latest-version.outputs.latest }}\"/" charts/langfuse/Chart.yaml
-          
+          sed -i "s/^appVersion: .*/appVersion: \"$LATEST_VERSION\"/" charts/langfuse/Chart.yaml
+
           echo "chart_version=$NEW_CHART_VERSION" >> $GITHUB_OUTPUT
+        env:
+          LATEST_VERSION: ${{ steps.latest-version.outputs.latest }}
 
       - name: Install helm-docs
         if: steps.version-check.outputs.needs_update == 'true'
@@ -85,12 +98,12 @@ jobs:
 
       - name: Create Pull Request
         if: steps.version-check.outputs.needs_update == 'true'
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: |
             chore: bump langfuse to ${{ steps.latest-version.outputs.latest }}
-            
+
             - Update appVersion to ${{ steps.latest-version.outputs.latest }}
             - Bump chart version to ${{ steps.update-chart.outputs.chart_version }}
             - Update generated documentation
@@ -98,15 +111,15 @@ jobs:
           body: |
             ## Summary
             This PR updates Langfuse to version ${{ steps.latest-version.outputs.latest }}.
-            
+
             ## Changes
             - ⬆️ Update appVersion from ${{ steps.current-version.outputs.current }} to ${{ steps.latest-version.outputs.latest }}
             - 📦 Bump chart version to ${{ steps.update-chart.outputs.chart_version }}
             - 📝 Update generated documentation
-            
+
             ## Automated Changes
             This PR was automatically created by the weekly version check workflow.
-            
+
             ---
             **Release Notes**: https://github.com/langfuse/langfuse/releases/tag/v${{ steps.latest-version.outputs.latest }}
           branch: update-langfuse-${{ steps.latest-version.outputs.latest }}

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -2,10 +2,14 @@ name: Validate Helm Charts
 on:
   pull_request:
     paths:
-      - 'charts/**'
+      - "charts/**"
 
 permissions:
-  contents: read
+  contents: read # Read repository contents for checkout and chart validation.
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   validate:
@@ -13,12 +17,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
         with:
           version: v3.13.2
 

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,36 @@
+---
+name: Check GitHub Actions
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - "main"
+  merge_group:
+  pull_request:
+    branches:
+      - "main"
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  zizmor:
+    name: Check GitHub Actions security
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # Upload SARIF results to GitHub code scanning.
+      contents: read # Read repository contents for workflow analysis.
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+          advanced-security: true


### PR DESCRIPTION
## Summary

- Add a zizmor GitHub Actions security workflow for k8s workflows and upload SARIF results to GitHub code scanning.
- Pin existing workflow actions to commit SHAs with precise version comments, disable checkout credential persistence, and tighten workflow permissions.
- Add weekly grouped Dependabot updates for GitHub Actions with the `ci` commit prefix and a 7-day cooldown.

## Linear

- [LFE-9748](https://linear.app/langfuse/issue/LFE-9748/zizmor-for-k8s)

## Major Decisions

- Kept release workflow concurrency from canceling in-progress runs to avoid interrupting chart publication while still preventing overlapping release runs.
- Left the existing `peter-evans/create-pull-request` workflow action in place because replacing it with `gh pr create` would change the automation behavior beyond trivial zizmor fixes.

## Review Focus

- Confirm the pinned action SHAs and precise tag comments match the intended versions.
- Confirm the explicit workflow permissions are sufficient for publishing test results, releases, SARIF, and automated Langfuse update PRs.