### PR TITLE
chore: add CODEOWNERS for GitHub config

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,4 @@
 # Default owner for everything in the repo
 * @Steffen911 
+# Require maintainer review for GitHub configuration changes
+.github/ @langfuse/maintainers


### PR DESCRIPTION
## Summary
- add/update `.github/CODEOWNERS` to require `@langfuse/maintainers` review for `.github/` changes

Linear: https://linear.app/langfuse/issue/LFE-9760/repo-owners-for-github-actions