### PR TITLE
feat: add HPA annotation values

### DIFF
--- a/charts/langfuse/README.md
+++ b/charts/langfuse/README.md
@@ -105,6 +105,7 @@ Open source LLM engineering platform - LLM observability, metrics, evaluations, 
 | langfuse.web.deployment.annotations | object | `{}` | Annotations for the web deployment |
 | langfuse.web.deployment.strategy | object | `{}` | Deployment strategy for the web deployment. Overrides the global deployment strategy |
 | langfuse.web.hostAliases | list | `[]` | Adding records to /etc/hosts in the pod's network. |
+| langfuse.web.hpa.annotations | object | `{}` | Annotations for the langfuse web HPA |
 | langfuse.web.hpa.enabled | bool | `false` | Set to `true` to enable HPA for the langfuse web pods Note: When both KEDA and HPA are enabled, the deployment will fail. |
 | langfuse.web.hpa.maxReplicas | int | `2` | The maximum number of replicas to use for the langfuse web pods |
 | langfuse.web.hpa.minReplicas | int | `1` | The minimum number of replicas to use for the langfuse web pods |
@@ -162,6 +163,7 @@ Open source LLM engineering platform - LLM observability, metrics, evaluations, 
 | langfuse.worker.deployment.additionalLabels | object | `{}` | Additional labels for the worker deployment |
 | langfuse.worker.deployment.annotations | object | `{}` | Annotations for the worker deployment |
 | langfuse.worker.deployment.strategy | object | `{}` | Deployment strategy for the worker deployment. Overrides the global deployment strategy |
+| langfuse.worker.hpa.annotations | object | `{}` | Annotations for the langfuse worker HPA |
 | langfuse.worker.hpa.enabled | bool | `false` | Set to `true` to enable HPA for the langfuse worker pods Note: When both KEDA and HPA are enabled, the deployment will fail. |
 | langfuse.worker.hpa.maxReplicas | int | `2` | The maximum number of replicas to use for the langfuse worker pods |
 | langfuse.worker.hpa.minReplicas | int | `1` | The minimum number of replicas to use for the langfuse worker pods |

--- a/charts/langfuse/templates/web/hpa.yaml
+++ b/charts/langfuse/templates/web/hpa.yaml
@@ -6,6 +6,10 @@ metadata:
   namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "langfuse.labels" . | nindent 4 }}
+  {{- with .Values.langfuse.web.hpa.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/charts/langfuse/templates/worker/hpa.yaml
+++ b/charts/langfuse/templates/worker/hpa.yaml
@@ -6,6 +6,10 @@ metadata:
   namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "langfuse.labels" . | nindent 4 }}
+  {{- with .Values.langfuse.worker.hpa.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/charts/langfuse/tests/hpa_test.yaml
+++ b/charts/langfuse/tests/hpa_test.yaml
@@ -1,0 +1,26 @@
+suite: test hpa configuration
+templates:
+  - web/hpa.yaml
+  - worker/hpa.yaml
+tests:
+  - it: should render HPA annotations for web and worker
+    values:
+      - ../values.lint.yaml
+      - values/hpa-annotations.yaml
+    asserts:
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/compare-options"]
+          value: IgnoreExtraneous
+        template: web/hpa.yaml
+      - equal:
+          path: metadata.annotations["example.com/web"]
+          value: enabled
+        template: web/hpa.yaml
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/compare-options"]
+          value: IgnoreExtraneous
+        template: worker/hpa.yaml
+      - equal:
+          path: metadata.annotations["example.com/worker"]
+          value: enabled
+        template: worker/hpa.yaml

--- a/charts/langfuse/tests/values/hpa-annotations.yaml
+++ b/charts/langfuse/tests/values/hpa-annotations.yaml
@@ -1,0 +1,13 @@
+langfuse:
+  web:
+    hpa:
+      enabled: true
+      annotations:
+        argocd.argoproj.io/compare-options: IgnoreExtraneous
+        example.com/web: enabled
+  worker:
+    hpa:
+      enabled: true
+      annotations:
+        argocd.argoproj.io/compare-options: IgnoreExtraneous
+        example.com/worker: enabled

--- a/charts/langfuse/values.yaml
+++ b/charts/langfuse/values.yaml
@@ -253,6 +253,8 @@ langfuse:
       # -- Set to `true` to enable HPA for the langfuse web pods
       # Note: When both KEDA and HPA are enabled, the deployment will fail.
       enabled: false
+      # -- Annotations for the langfuse web HPA
+      annotations: {}
       # -- The minimum number of replicas to use for the langfuse web pods
       minReplicas: 1
       # -- The maximum number of replicas to use for the langfuse web pods
@@ -385,6 +387,8 @@ langfuse:
       # -- Set to `true` to enable HPA for the langfuse worker pods
       # Note: When both KEDA and HPA are enabled, the deployment will fail.
       enabled: false
+      # -- Annotations for the langfuse worker HPA
+      annotations: {}
       # -- The minimum number of replicas to use for the langfuse worker pods
       minReplicas: 1
       # -- The maximum number of replicas to use for the langfuse worker pods


### PR DESCRIPTION
## Summary
- add web and worker HPA annotation values
- render configured annotations on HPA metadata
- document the new values and cover Argo CD-style annotation keys in chart tests

## Validation
- helm lint charts/langfuse --values charts/langfuse/values.lint.yaml
- helm unittest charts/langfuse --color