### PR TITLE
feat(langfuse): support hostAliases on worker deployment (parity with web)

### DIFF
--- a/charts/langfuse/README.md
+++ b/charts/langfuse/README.md
@@ -163,6 +163,7 @@ Open source LLM engineering platform - LLM observability, metrics, evaluations, 
 | langfuse.worker.deployment.additionalLabels | object | `{}` | Additional labels for the worker deployment |
 | langfuse.worker.deployment.annotations | object | `{}` | Annotations for the worker deployment |
 | langfuse.worker.deployment.strategy | object | `{}` | Deployment strategy for the worker deployment. Overrides the global deployment strategy |
+| langfuse.worker.hostAliases | list | `[]` | Adding records to /etc/hosts in the worker pod's network. |
 | langfuse.worker.hpa.annotations | object | `{}` | Annotations for the langfuse worker HPA |
 | langfuse.worker.hpa.enabled | bool | `false` | Set to `true` to enable HPA for the langfuse worker pods Note: When both KEDA and HPA are enabled, the deployment will fail. |
 | langfuse.worker.hpa.maxReplicas | int | `2` | The maximum number of replicas to use for the langfuse worker pods |

--- a/charts/langfuse/templates/worker/deployment.yaml
+++ b/charts/langfuse/templates/worker/deployment.yaml
@@ -42,6 +42,10 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.langfuse.worker.hostAliases }}
+      hostAliases:
+        {{- toYaml .Values.langfuse.worker.hostAliases | nindent 8 }}
+      {{- end }}
       {{- with (.Values.langfuse.worker.image.pullSecrets | default .Values.langfuse.image.pullSecrets) }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/langfuse/values.yaml
+++ b/charts/langfuse/values.yaml
@@ -318,6 +318,8 @@ langfuse:
 
   # Worker deployment configuration
   worker:
+    # -- Adding records to /etc/hosts in the worker pod's network.
+    hostAliases: []
     image:
       # -- The image repository to use for the langfuse worker pods
       repository: langfuse/langfuse-worker


### PR DESCRIPTION
## What
Adds `langfuse.worker.hostAliases`, mirroring the existing `langfuse.web.hostAliases`.

## Why
The web deployment supports custom `/etc/hosts` entries via `langfuse.web.hostAliases`, but the worker deployment does not.

Our use case is an edge case behind a load balancer with **NAT (hairpin / NAT-loopback)**: in-cluster workloads cannot connect to the load balancer's **public** IP directly. The S3/blob endpoint's public hostname therefore has to be redirected to the **internal** load balancer IP. Because there is no internal / split-horizon DNS for that hostname, the redirect must be hardcoded via `hostAliases`.

The Langfuse **worker** performs the actual S3 event/media/batch uploads, so it needs this mapping just as much as the web pod — but today it cannot get it through Helm values.

## Changes
- `templates/worker/deployment.yaml`: render `hostAliases` when `langfuse.worker.hostAliases` is set
- `values.yaml`: add `langfuse.worker.hostAliases: []` with doc comment (mirrors web)

## Notes
- Direct mirror of the web implementation; **no behavior change when unset** (default `[]`).
- Verified with `helm template` (worker pod now renders `hostAliases` when set) and `helm lint`.
- Open to making this a shared `langfuse.hostAliases` (web + worker) instead, if maintainers prefer that direction.
