### PR TITLE
feat(chart): add optional startupProbe for web and worker

### DIFF
--- a/charts/langfuse/Chart.yaml
+++ b/charts/langfuse/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: langfuse
-version: 1.5.35
+version: 1.6.0
 description: Open source LLM engineering platform - LLM observability, metrics, evaluations, prompt management.
 type: application
 keywords:

--- a/charts/langfuse/README.md
+++ b/charts/langfuse/README.md
@@ -1,6 +1,6 @@
 # langfuse
 
-![Version: 1.5.35](https://img.shields.io/badge/Version-1.5.35-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.185.0](https://img.shields.io/badge/AppVersion-3.185.0-informational?style=flat-square)
+![Version: 1.6.0](https://img.shields.io/badge/Version-1.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.185.0](https://img.shields.io/badge/AppVersion-3.185.0-informational?style=flat-square)
 
 Open source LLM engineering platform - LLM observability, metrics, evaluations, prompt management.
 
@@ -155,6 +155,13 @@ Open source LLM engineering platform - LLM observability, metrics, evaluations, 
 | langfuse.web.service.nodePort | string | `nil` | The node port to use for the langfuse web application |
 | langfuse.web.service.port | int | `3000` | The port to use for the langfuse web application |
 | langfuse.web.service.type | string | `"ClusterIP"` | The type of service to use for the langfuse web application |
+| langfuse.web.startupProbe.enabled | bool | `false` | Set to `true` to enable the startupProbe for the langfuse web pods. |
+| langfuse.web.startupProbe.failureThreshold | int | `30` | Failure threshold for startupProbe. With the default periodSeconds this allows ~5 minutes for startup. |
+| langfuse.web.startupProbe.initialDelaySeconds | int | `0` | Initial delay seconds for startupProbe. |
+| langfuse.web.startupProbe.path | string | `"/api/public/health"` | Path to check for startup. |
+| langfuse.web.startupProbe.periodSeconds | int | `10` | Period seconds for startupProbe. |
+| langfuse.web.startupProbe.successThreshold | int | `1` | Success threshold for startupProbe. |
+| langfuse.web.startupProbe.timeoutSeconds | int | `5` | Timeout seconds for startupProbe. |
 | langfuse.web.vpa.controlledResources | list | `[]` | The resources to control for the langfuse web pods |
 | langfuse.web.vpa.enabled | bool | `false` | Set to `true` to enable VPA for the langfuse web pods |
 | langfuse.web.vpa.maxAllowed | object | `{}` | The maximum allowed resources for the langfuse web pods |
@@ -201,6 +208,12 @@ Open source LLM engineering platform - LLM observability, metrics, evaluations, 
 | langfuse.worker.replicas | string | `nil` | Number of replicas to use if HPA is not enabled. Defaults to the global replicas |
 | langfuse.worker.resources | object | `{}` | Resources for the langfuse worker pods. Defaults to the global resources |
 | langfuse.worker.revisionHistoryLimit | string | `nil` | Number of old ReplicaSets to retain to allow rollback. |
+| langfuse.worker.startupProbe.enabled | bool | `false` | Set to `true` to enable the startupProbe for the langfuse worker pods. |
+| langfuse.worker.startupProbe.failureThreshold | int | `30` | Failure threshold for startupProbe. With the default periodSeconds this allows ~5 minutes for startup. |
+| langfuse.worker.startupProbe.initialDelaySeconds | int | `0` | Initial delay seconds for startupProbe. |
+| langfuse.worker.startupProbe.periodSeconds | int | `10` | Period seconds for startupProbe. |
+| langfuse.worker.startupProbe.successThreshold | int | `1` | Success threshold for startupProbe. |
+| langfuse.worker.startupProbe.timeoutSeconds | int | `5` | Timeout seconds for startupProbe. |
 | langfuse.worker.vpa.controlledResources | list | `[]` | The resources to control for the langfuse worker pods |
 | langfuse.worker.vpa.enabled | bool | `false` | Set to `true` to enable VPA for the langfuse worker pods |
 | langfuse.worker.vpa.maxAllowed | object | `{}` | The maximum allowed resources for the langfuse worker pods |

--- a/charts/langfuse/templates/web/deployment.yaml
+++ b/charts/langfuse/templates/web/deployment.yaml
@@ -93,6 +93,17 @@ spec:
             - name: http
               containerPort: {{ .Values.langfuse.web.service.port }}
               protocol: TCP
+          {{- if .Values.langfuse.web.startupProbe.enabled }}
+          startupProbe:
+            httpGet:
+              path: {{ .Values.langfuse.web.startupProbe.path | default "/api/public/health" }}
+              port: http
+            initialDelaySeconds: {{ .Values.langfuse.web.startupProbe.initialDelaySeconds | default 0 }}
+            periodSeconds: {{ .Values.langfuse.web.startupProbe.periodSeconds | default 10 }}
+            timeoutSeconds: {{ .Values.langfuse.web.startupProbe.timeoutSeconds | default 5 }}
+            successThreshold: {{ .Values.langfuse.web.startupProbe.successThreshold | default 1 }}
+            failureThreshold: {{ .Values.langfuse.web.startupProbe.failureThreshold | default 30 }}
+          {{- end }}
           livenessProbe:
             httpGet:
               path: {{ .Values.langfuse.web.livenessProbe.path | default "/api/public/health" }}

--- a/charts/langfuse/templates/worker/deployment.yaml
+++ b/charts/langfuse/templates/worker/deployment.yaml
@@ -91,6 +91,17 @@ spec:
             - name: http
               containerPort: {{ .Values.langfuse.worker.port | default 3030 }}
               protocol: TCP
+          {{- if .Values.langfuse.worker.startupProbe.enabled }}
+          startupProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            initialDelaySeconds: {{ .Values.langfuse.worker.startupProbe.initialDelaySeconds | default 0 }}
+            periodSeconds: {{ .Values.langfuse.worker.startupProbe.periodSeconds | default 10 }}
+            timeoutSeconds: {{ .Values.langfuse.worker.startupProbe.timeoutSeconds | default 5 }}
+            successThreshold: {{ .Values.langfuse.worker.startupProbe.successThreshold | default 1 }}
+            failureThreshold: {{ .Values.langfuse.worker.startupProbe.failureThreshold | default 30 }}
+          {{- end }}
           livenessProbe:
             httpGet:
               path: /api/health

--- a/charts/langfuse/tests/startup-probe_test.yaml
+++ b/charts/langfuse/tests/startup-probe_test.yaml
@@ -1,0 +1,47 @@
+suite: test startupProbe configuration
+templates:
+  - web/deployment.yaml
+  - worker/deployment.yaml
+tests:
+  - it: should not render a startupProbe by default
+    values:
+      - ../values.lint.yaml
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].startupProbe
+        template: web/deployment.yaml
+      - notExists:
+          path: spec.template.spec.containers[0].startupProbe
+        template: worker/deployment.yaml
+
+  - it: should render the web startupProbe when enabled
+    values:
+      - ../values.lint.yaml
+    set:
+      langfuse.web.startupProbe.enabled: true
+    asserts:
+      - exists:
+          path: spec.template.spec.containers[0].startupProbe
+        template: web/deployment.yaml
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.httpGet.path
+          value: /api/public/health
+        template: web/deployment.yaml
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.failureThreshold
+          value: 30
+        template: web/deployment.yaml
+
+  - it: should render the worker startupProbe when enabled
+    values:
+      - ../values.lint.yaml
+    set:
+      langfuse.worker.startupProbe.enabled: true
+    asserts:
+      - exists:
+          path: spec.template.spec.containers[0].startupProbe
+        template: worker/deployment.yaml
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.httpGet.path
+          value: /api/health
+        template: worker/deployment.yaml

--- a/charts/langfuse/values.yaml
+++ b/charts/langfuse/values.yaml
@@ -307,6 +307,23 @@ langfuse:
       # -- Success threshold for readinessProbe.
       successThreshold: 1
 
+    # Startup probe configuration for the web deployment
+    startupProbe:
+      # -- Set to `true` to enable the startupProbe for the langfuse web pods.
+      enabled: false
+      # -- Path to check for startup.
+      path: "/api/public/health"
+      # -- Initial delay seconds for startupProbe.
+      initialDelaySeconds: 0
+      # -- Period seconds for startupProbe.
+      periodSeconds: 10
+      # -- Timeout seconds for startupProbe.
+      timeoutSeconds: 5
+      # -- Failure threshold for startupProbe. With the default periodSeconds this allows ~5 minutes for startup.
+      failureThreshold: 30
+      # -- Success threshold for startupProbe.
+      successThreshold: 1
+
     # Pod Disruption Budget configuration for the web deployment
     pdb:
       # -- Set to `true` to create a Pod Disruption Budget for the langfuse web pods
@@ -431,6 +448,21 @@ langfuse:
       # -- Failure threshold for livenessProbe.
       failureThreshold: 3
       # -- Success threshold for livenessProbe.
+      successThreshold: 1
+
+    # Startup probe configuration for the worker deployment
+    startupProbe:
+      # -- Set to `true` to enable the startupProbe for the langfuse worker pods.
+      enabled: false
+      # -- Initial delay seconds for startupProbe.
+      initialDelaySeconds: 0
+      # -- Period seconds for startupProbe.
+      periodSeconds: 10
+      # -- Timeout seconds for startupProbe.
+      timeoutSeconds: 5
+      # -- Failure threshold for startupProbe. With the default periodSeconds this allows ~5 minutes for startup.
+      failureThreshold: 30
+      # -- Success threshold for startupProbe.
       successThreshold: 1
 
   # NextAuth configuration


### PR DESCRIPTION
## Problem

`langfuse-web` (and `langfuse-worker`) run only a `livenessProbe` + `readinessProbe`. If the container takes longer to boot than the liveness budget — `initialDelaySeconds + failureThreshold × periodSeconds`, ~50s with the chart defaults (`20 + 3×10`) — the kubelet `SIGTERM`-kills it mid-boot (exit code 143) before `/api/public/health` can answer. It restarts, boots slowly again, gets killed again → a permanent `CrashLoopBackOff`, never reaching Ready.

This is easy to hit after an app-version bump that lengthens startup (e.g. a longer DB/ClickHouse migration or a cold start under node contention). The chart exposes no `startupProbe`, so today the only workaround is loosening the `livenessProbe` — which also weakens genuine hang detection.

## Change

Add an **opt-in `startupProbe`** (default `enabled: false`, so this is a no-op for existing installs) to both the web and worker deployments. When enabled, Kubernetes runs only the startup probe until it first succeeds and does not run liveness/readiness (and cannot restart the pod) until then — giving a slow first boot a generous window while keeping the liveness probe tight.

- `values.yaml`: `langfuse.web.startupProbe` and `langfuse.worker.startupProbe`. Defaults give a ~5-minute startup budget when enabled (`failureThreshold: 30` × `periodSeconds: 10`).
- `templates/web/deployment.yaml` and `templates/worker/deployment.yaml`: render the probe only when `enabled`.
- `tests/startup-probe_test.yaml`: helm-unittest suite covering default-off and enabled-on for both deployments.
- README regenerated via helm-docs; chart version `1.5.35 → 1.6.0`.

## Backward compatibility

Default-disabled → rendered output is unchanged for existing values. Verified with `helm template` (no `startupProbe` by default; present with the configured values when enabled).

## Testing

- `helm lint charts/langfuse/ -f charts/langfuse/values.lint.yaml` → passes
- `helm unittest charts/langfuse/` → 12 suites / 65 tests pass (incl. the new suite)
- `helm-docs` → README in sync

Example usage:
```yaml
langfuse:
  web:
    startupProbe:
      enabled: true
  worker:
    startupProbe:
      enabled: true
```
