### PR TITLE
docs: document ClickHouse operator usage and add v4 installation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,144 @@ Langfuse self-hosting documentation: https://langfuse.com/self-hosting
 - `examples` directory contains example `yaml` configurations
 - `charts/langfuse` directory contains Helm chart for deploying Langfuse with an associated database
 
+## Installing Langfuse v4
+
+For new installations or existing installations with an external ClickHouse cluster (version >25.12), we recommend to adopt [Langfuse v4](https://langfuse.com/docs/v4).
+
+Please follow the [Langfuse v4 installation example](/examples/v4-installation).
+
+If you want to upgrade an existing installation, please follow our [upgrade guide](https://langfuse.com/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4).
+In case you run the Bitnami-based chart, please hold off from migrations for now, as the included ClickHouse version does not support Langfuse v4 yet.
+We will publish updates in our [GitHub discussion](https://github.com/orgs/langfuse/discussions/12518) once a supported upgrade path is established.
+You can also subscribe to [OSS release updates](https://langfuse.com/self-hosting/upgrade#release-notes) on our website.
+
+## Recommended Setup
+
+The Helm chart bundles PostgreSQL, ClickHouse, Redis, and MinIO as sub-charts so that a single `helm install` gives you a complete Langfuse deployment out of the box.
+This remains a quick way to get started, and existing installations based on the bundled sub-charts continue to work as before.
+
+For new installations, we recommend connecting the chart to components that you manage outside of it wherever possible.
+This is the most future-proof setup: your data stores are decoupled from chart releases, can be upgraded and scaled independently, and you always have access to the latest component versions.
+Additionally, you can benefit from managed components that often offer automatic backups and other convenience functions.
+It is also the setup that future improvements of this chart will build on.
+
+- **ClickHouse**: Run your own cluster with the official [ClickHouse Kubernetes Operator](https://github.com/ClickHouse/clickhouse-operator) — see the [tutorial below](#deploy-clickhouse-with-the-clickhouse-operator) — or connect a managed [ClickHouse Cloud](https://clickhouse.com/cloud) service ([example](#with-an-external-clickhouse-cluster)).
+- **PostgreSQL**: Use a managed service if available to you, e.g. Amazon RDS, Azure Database for PostgreSQL, or Google Cloud SQL ([example](#with-an-external-postgres-server)).
+- **Redis**: Use a managed service if available to you, e.g. Amazon ElastiCache, Azure Cache for Redis, or Google Memorystore ([example](#with-redis-cluster)).
+- **Blob Storage**: Use Amazon S3, Azure Blob Storage, Google Cloud Storage, or another S3-compatible service if available to you ([examples](#with-an-external-s3-bucket)).
+
+For all new setups we recommend the following minimum versions to ensure compatibility with [Langfuse v4](https://langfuse.com/docs/v4), our upcoming major release.
+- ClickHouse: 25.12 minimum, 26.4 recommended.
+- Postgres: 16 recommended.
+- Redis: 7.2 recommended.
+
+Please note that the ClickHouse version that comes bundled with this chart is _not_ compatible with Langfuse v4.
+We are currently exploring options for migrations and for replacing it.
+
+All external components are connected through your `values.yaml` file — see the linked examples. Components that you do not bring yourself are deployed by the chart as before.
+
+### Deploy ClickHouse with the ClickHouse Operator
+
+The official [ClickHouse Kubernetes Operator](https://github.com/ClickHouse/clickhouse-operator) is the recommended way to run a self-managed ClickHouse cluster on Kubernetes.
+It automates deployment, upgrades, scaling, and high availability of ClickHouse and ClickHouse Keeper clusters, and lets you run current ClickHouse releases independent of this chart's release cycle.
+See the [Langfuse ClickHouse documentation](https://langfuse.com/self-hosting/deployment/infrastructure/clickhouse) for background on how Langfuse uses ClickHouse.
+
+1. Install [cert-manager](https://cert-manager.io/), which the operator requires for its webhook certificates (skip if it is already installed in your cluster):
+
+   ```bash
+   helm install cert-manager oci://quay.io/jetstack/charts/cert-manager \
+     --version v1.20.2 \
+     --namespace cert-manager --create-namespace \
+     --set crds.enabled=true
+   ```
+
+2. Install the ClickHouse operator (once per Kubernetes cluster):
+
+   ```bash
+   helm install clickhouse-operator oci://ghcr.io/clickhouse/clickhouse-operator-helm \
+     --version 0.0.5 \
+     --namespace clickhouse-operator --create-namespace
+   ```
+
+3. Create a Secret with the ClickHouse password in the namespace that Langfuse will be installed into (`langfuse` in this example):
+
+   ```bash
+   kubectl create namespace langfuse
+   kubectl create secret generic langfuse-clickhouse-auth \
+     --namespace langfuse \
+     --from-literal=password="$(openssl rand -hex 32)"
+   ```
+
+4. Create a `clickhouse-cluster.yaml` containing a `KeeperCluster` and a `ClickHouseCluster` resource (see [examples/v4-installation](examples/v4-installation/clickhouse-cluster.yaml)):
+
+   ```yaml
+   apiVersion: clickhouse.com/v1alpha1
+   kind: KeeperCluster
+   metadata:
+     name: langfuse
+   spec:
+     replicas: 3 # Must be an odd number, use 3 for high availability
+     containerTemplate:
+       image:
+         repository: clickhouse/clickhouse-keeper
+         tag: "26.4"
+     dataVolumeClaimSpec:
+       resources:
+         requests:
+           storage: 10Gi
+   ---
+   apiVersion: clickhouse.com/v1alpha1
+   kind: ClickHouseCluster
+   metadata:
+     name: langfuse
+   spec:
+     replicas: 3 # We recommend 3 replicas for production setups, 1 is sufficient for evaluations
+     shards: 1 # Fixed - Langfuse does not support sharding
+     keeperClusterRef:
+       name: langfuse
+     containerTemplate:
+       image:
+         repository: clickhouse/clickhouse-server
+         tag: "26.4" # Pick a current ClickHouse release
+     dataVolumeClaimSpec:
+       resources:
+         requests:
+           storage: 100Gi # Start with a large volume to prevent early resizing
+     settings:
+       defaultUserPassword:
+         secret:
+           name: langfuse-clickhouse-auth
+           key: password
+   ```
+
+   Apply it and wait until both resources report `Ready`:
+
+   ```bash
+   kubectl apply --namespace langfuse -f clickhouse-cluster.yaml
+   kubectl wait --for=condition=Ready --timeout=600s \
+     keepercluster/langfuse clickhousecluster/langfuse \
+     --namespace langfuse
+   ```
+
+5. Connect the cluster in your `values.yaml`. The operator exposes the cluster through a headless service named `<name>-clickhouse-headless`:
+
+   ```yaml
+   clickhouse:
+     deploy: false
+     host: langfuse-clickhouse-headless # FQDN: langfuse-clickhouse-headless.langfuse.svc.cluster.local
+     auth:
+       username: default
+       existingSecret: langfuse-clickhouse-auth
+       existingSecretKey: password
+   ```
+
+   The operator configures the ClickHouse cluster name as `default`, which matches the chart's defaults, so no further changes are required.
+   See our [v4-installation](examples/v4-installation) for a fully configured example.
+
+6. Continue with the regular [chart installation](#installation) in the same namespace, e.g. `helm install langfuse langfuse/langfuse --namespace langfuse -f values.yaml`.
+
+For TLS, pod scheduling, monitoring, and other options, see the [operator documentation](https://clickhouse.com/docs/clickhouse-operator/overview).
+
 ## ⚠️ Important: Bitnami Registry Changes
 
 **Effective August 28, 2025**, Bitnami will restructure its container registry. This chart now uses `bitnamilegacy/*` images by default to prevent deployment failures.
@@ -27,6 +165,7 @@ Langfuse self-hosting documentation: https://langfuse.com/self-hosting
 - For existing deployments: Ensure that you update your mirrors to clone from bitnamilegacy if applicable.
 - We will investigate alternative image sources that are compliant with the Helm chart and roll them out over time.
 - You _may_ upgrade to Bitnami Secure Images if desired in the meantime. In this case, set `global.security.allowInsecureImages: false` and configure image repositories to use `bitnami/*` instead of `bitnamilegacy/*`
+- For ClickHouse, you can avoid Bitnami images entirely by connecting an external cluster, e.g. via the ClickHouse operator.
 
 See [Bitnami's announcement](https://github.com/bitnami/charts/issues/35164) for more details.
 
@@ -219,6 +358,36 @@ postgresql:
   host: my-external-postgres-server.com
   directUrl: postgres://my-username:my-password@my-external-postgres-server.com
   shadowDatabaseUrl: postgres://my-username:my-password@my-external-postgres-server.com
+```
+
+##### With an external ClickHouse cluster
+
+This works for any ClickHouse deployment that runs outside of this chart, e.g. a cluster managed by the [ClickHouse Operator](#deploy-clickhouse-with-the-clickhouse-operator):
+
+```yaml
+[...]
+clickhouse:
+  deploy: false
+  host: my-clickhouse-host # For single-node instances, also set clickhouse.clusterEnabled: false
+  auth:
+    username: default
+    password: my-password
+```
+
+For [ClickHouse Cloud](https://clickhouse.com/cloud), use the HTTPS endpoint of your service together with the secure ports and SSL for migrations:
+
+```yaml
+[...]
+clickhouse:
+  deploy: false
+  host: https://<identifier>.<region>.aws.clickhouse.cloud
+  httpPort: 8443
+  nativePort: 9440
+  auth:
+    username: default
+    password: my-password
+  migration:
+    ssl: true
 ```
 
 ##### With an external S3 bucket

--- a/examples/v4-installation/README.md
+++ b/examples/v4-installation/README.md
@@ -1,0 +1,86 @@
+# Langfuse v4 Installation Example
+
+This example demonstrates a complete [Langfuse v4](https://langfuse.com/docs/v4) installation in a Kubernetes cluster.
+ClickHouse runs outside of the Helm chart and is managed by the official [ClickHouse Kubernetes Operator](https://github.com/ClickHouse/clickhouse-operator), as the ClickHouse version bundled with the chart is not compatible with Langfuse v4.
+All other components (PostgreSQL, Redis, MinIO) are deployed by the chart as usual.
+
+See the [Recommended Setup](../../README.md#recommended-setup) section in the repository README for background on this architecture.
+
+## Installation
+
+To install Langfuse v4 using this example:
+
+1. Install [cert-manager](https://cert-manager.io/), which the ClickHouse operator requires for its webhook certificates (skip if it is already installed in your cluster):
+
+   ```bash
+   helm install cert-manager oci://quay.io/jetstack/charts/cert-manager \
+     --version v1.20.2 \
+     --namespace cert-manager --create-namespace \
+     --set crds.enabled=true
+   ```
+
+2. Install the ClickHouse operator (once per Kubernetes cluster):
+
+   ```bash
+   helm install clickhouse-operator oci://ghcr.io/clickhouse/clickhouse-operator-helm \
+     --version 0.0.5 \
+     --namespace clickhouse-operator --create-namespace
+   ```
+
+3. Create the namespace and the required secrets:
+
+   ```bash
+   kubectl create namespace langfuse
+
+   # Edit secret.yaml and set secure values before applying
+   kubectl apply --namespace langfuse -f secret.yaml
+
+   # The ClickHouse password lives in a separate secret that is shared between
+   # the operator-managed ClickHouse cluster and the Langfuse chart
+   kubectl create secret generic langfuse-clickhouse-auth \
+     --namespace langfuse \
+     --from-literal=password="$(openssl rand -hex 32)"
+   ```
+
+4. Create the ClickHouse and ClickHouse Keeper clusters and wait until both report `Ready`:
+
+   ```bash
+   kubectl apply --namespace langfuse -f clickhouse-cluster.yaml
+   kubectl wait --for=condition=Ready --timeout=600s \
+     keepercluster/langfuse clickhousecluster/langfuse \
+     --namespace langfuse
+   ```
+
+5. Install the chart into the same namespace using the values file:
+
+   ```bash
+   helm repo add langfuse https://langfuse.github.io/langfuse-k8s
+   helm repo update
+   helm install langfuse langfuse/langfuse --namespace langfuse -f values.yaml
+   ```
+
+## Configuration
+
+The example contains three configuration files:
+
+### `secret.yaml`
+
+Contains the application secrets for the Langfuse installation. **Must be applied before installing the Helm chart**. Make sure to replace all placeholder values with secure values before applying.
+
+The ClickHouse password is intentionally not part of this secret: it is stored in the separate `langfuse-clickhouse-auth` secret created in step 3, because it is shared between the operator-managed ClickHouse cluster and the Langfuse chart.
+
+### `clickhouse-cluster.yaml`
+
+Defines the `KeeperCluster` and `ClickHouseCluster` resources that the ClickHouse operator turns into a running, replicated ClickHouse cluster. The `defaultUserPassword` setting references the `langfuse-clickhouse-auth` secret, so the `default` user is created with the same password that the chart uses to connect.
+
+Adjust `replicas`, the ClickHouse image `tag`, and the requested `storage` to your environment before applying. For TLS, pod scheduling, monitoring, and other options, see the [operator documentation](https://clickhouse.com/docs/clickhouse-operator/overview).
+
+### `values.yaml`
+
+The core values file. It pins the Langfuse image to a v4 release, configures the chart to read all required credentials from the pre-created secrets, and connects Langfuse to the operator-managed ClickHouse cluster instead of deploying the bundled ClickHouse sub-chart.
+
+The operator exposes the ClickHouse cluster through a headless service named `<name>-clickhouse-headless` and configures the ClickHouse cluster name as `default`, which matches the chart's defaults, so no further ClickHouse-related changes are required.
+
+## Ingress
+
+This example does not expose Langfuse outside of the cluster. To enable an ingress, see the [ingress examples](../../README.md#enable-ingress) in the repository README.

--- a/examples/v4-installation/clickhouse-cluster.yaml
+++ b/examples/v4-installation/clickhouse-cluster.yaml
@@ -1,0 +1,37 @@
+apiVersion: clickhouse.com/v1alpha1
+kind: KeeperCluster
+metadata:
+  name: langfuse
+spec:
+  replicas: 3 # Must be an odd number, use 3 for high availability
+  containerTemplate:
+    image:
+      repository: clickhouse/clickhouse-keeper
+      tag: "26.4"
+  dataVolumeClaimSpec:
+    resources:
+      requests:
+        storage: 10Gi
+---
+apiVersion: clickhouse.com/v1alpha1
+kind: ClickHouseCluster
+metadata:
+  name: langfuse
+spec:
+  replicas: 3 # We recommend 3 replicas for production setups, 1 is sufficient for evaluations
+  shards: 1 # Fixed - Langfuse does not support sharding
+  keeperClusterRef:
+    name: langfuse
+  containerTemplate:
+    image:
+      repository: clickhouse/clickhouse-server
+      tag: "26.4" # Pick a current ClickHouse release
+  dataVolumeClaimSpec:
+    resources:
+      requests:
+        storage: 100Gi # Start with a large volume to prevent early resizing
+  settings:
+    defaultUserPassword:
+      secret:
+        name: langfuse-clickhouse-auth
+        key: password

--- a/examples/v4-installation/secret.yaml
+++ b/examples/v4-installation/secret.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: langfuse
+stringData:
+  salt: your-salt
+  encryption-key: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef # Generate with `openssl rand -hex 32`
+  nextauth-secret: your-nextauth-secret
+  postgresql-password: your-postgresql-password
+  redis-password: your-redis-password
+  s3-user: your-s3-user
+  s3-password: your-s3-password

--- a/examples/v4-installation/values.yaml
+++ b/examples/v4-installation/values.yaml
@@ -1,0 +1,49 @@
+# This values.yaml file demonstrates a Langfuse v4 installation that connects to an
+# external ClickHouse cluster managed by the ClickHouse Kubernetes Operator.
+# All credentials are read from pre-created secrets. Secrets must be set manually or via
+# External Secrets Operator like https://external-secrets.io/latest or any other secret management tool.
+langfuse:
+  image:
+    tag: "4.0.0-rc.3" # Pick a current Langfuse v4 release
+
+  encryptionKey:
+    secretKeyRef:
+      name: langfuse
+      key: encryption-key
+
+  salt:
+    secretKeyRef:
+      name: langfuse
+      key: salt
+
+  nextauth:
+    secret:
+      secretKeyRef:
+        name: langfuse
+        key: nextauth-secret
+
+postgresql:
+  auth:
+    existingSecret: langfuse
+    secretKeys:
+      adminPasswordKey: postgresql-password
+      userPasswordKey: postgresql-password
+
+clickhouse:
+  deploy: false
+  host: langfuse-clickhouse-headless # FQDN: langfuse-clickhouse-headless.langfuse.svc.cluster.local
+  auth:
+    username: default
+    existingSecret: langfuse-clickhouse-auth
+    existingSecretKey: password
+
+redis:
+  auth:
+    existingSecret: langfuse
+    existingSecretPasswordKey: redis-password
+
+s3:
+  auth:
+    existingSecret: langfuse
+    rootUserSecretKey: s3-user
+    rootPasswordSecretKey: s3-password


### PR DESCRIPTION
## Summary

Documents how to run Langfuse with an external, operator-managed ClickHouse cluster and ships a complete Langfuse v4 installation example. The ClickHouse version bundled with the chart is not compatible with Langfuse v4, so this establishes the recommended path for new installations.

### README

- New **Installing Langfuse v4** section pointing to the new example, the v3→v4 upgrade guide, and the GitHub discussion for Bitnami-based installations.
- New **Recommended Setup** section: recommends externally managed components (ClickHouse via the official [ClickHouse Kubernetes Operator](https://github.com/ClickHouse/clickhouse-operator) or ClickHouse Cloud, managed Postgres/Redis/blob storage) for new installations, with minimum version recommendations for v4 compatibility.
- Step-by-step tutorial for deploying ClickHouse and ClickHouse Keeper with the operator and connecting the cluster to the chart.
- New **With an external ClickHouse cluster** values example, including ClickHouse Cloud connection settings.
- Note in the Bitnami registry section that an external ClickHouse cluster avoids Bitnami images entirely.

### examples/v4-installation

Complete, self-contained v4 example:

- `clickhouse-cluster.yaml` — `KeeperCluster` + `ClickHouseCluster` resources with the default user password sourced from a shared secret.
- `secret.yaml` — application secrets template for the chart.
- `values.yaml` — pins a Langfuse v4 image, reads all credentials from pre-created secrets, and connects to the operator-managed ClickHouse instead of the bundled sub-chart.
- `README.md` — installation walkthrough (cert-manager → operator → secrets → ClickHouse cluster → chart install).

🤖 Generated with [Claude Code](https://claude.com/claude-code)