### PR TITLE
feat: add ClickHouse data retention management via CronJob

### DIFF
--- a/charts/langfuse/templates/clickhouse-retention.yaml
+++ b/charts/langfuse/templates/clickhouse-retention.yaml
@@ -1,0 +1,170 @@
+{{- if and .Values.clickhouse.deploy .Values.clickhouse.retention.enabled }}
+---
+# ConfigMap containing the SQL retention script (idempotent).
+# Operates on the "default" database, matching the standard Langfuse ClickHouse deployment.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "langfuse.fullname" . }}-clickhouse-retention-sql
+  labels:
+    {{- include "langfuse.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": hook-succeeded
+data:
+  retention.sql: |
+    -- Idempotent: safe to run on every CronJob execution without side effects.
+    -- Appends TTL retention policy to tables (no-op if already set).
+    ALTER TABLE default.traces
+      MODIFY TTL timestamp + INTERVAL {{ .Values.clickhouse.retention.ttlDays }} DAY DELETE;
+
+    ALTER TABLE default.observations
+      MODIFY TTL start_time + INTERVAL {{ .Values.clickhouse.retention.ttlDays }} DAY DELETE;
+
+    ALTER TABLE default.scores
+      MODIFY TTL timestamp + INTERVAL {{ .Values.clickhouse.retention.ttlDays }} DAY DELETE;
+
+    -- If you also ingest via OTel (unified table):
+    -- ALTER TABLE default.events_full
+    --   MODIFY TTL timestamp + INTERVAL {{ .Values.clickhouse.retention.ttlDays }} DAY DELETE;
+
+---
+# CronJob: re-applies the TTL policy daily.
+# Cost is negligible — it only updates metadata. ClickHouse automatically purges
+# expired data during background merges.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "langfuse.fullname" . }}-clickhouse-retention
+  labels:
+    {{- include "langfuse.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  schedule: "{{ .Values.clickhouse.retention.schedule }}"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: {{ .Values.clickhouse.retention.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.clickhouse.retention.failedJobsHistoryLimit }}
+  jobTemplate:
+    spec:
+      backoffLimit: {{ .Values.clickhouse.retention.backoffLimit }}
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: clickhouse-retention
+              image: {{ .Values.clickhouse.retention.image.repository }}:{{ .Values.clickhouse.retention.image.tag }}
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -eu
+                  clickhouse-client \
+                    --host="{{ include "langfuse.fullname" . }}-clickhouse" \
+                    --port={{ .Values.clickhouse.nativePort }} \
+                    --user={{ .Values.clickhouse.auth.username }} \
+                    --password="$(CLICKHOUSE_PASSWORD)" \
+                    --multiquery < /sql/retention.sql
+              env:
+                - name: CLICKHOUSE_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      {{- if .Values.clickhouse.auth.existingSecret }}
+                      name: {{ .Values.clickhouse.auth.existingSecret }}
+                      {{- else }}
+                      name: {{ include "langfuse.fullname" . }}-clickhouse
+                      {{- end }}
+                      key: {{ .Values.clickhouse.auth.existingSecretKey | default "clickhouse-password" }}
+              volumeMounts:
+                - name: sql
+                  mountPath: /sql
+          volumes:
+            - name: sql
+              configMap:
+                name: {{ include "langfuse.fullname" . }}-clickhouse-retention-sql
+
+---
+# One-shot Job: run manually ONCE to immediately purge existing data older
+# than the TTL. Without this, the TTL only applies to new data and existing
+# data is cleaned gradually during background merges (which can be slow).
+# kubectl delete job <release>-clickhouse-retention-backfill -n <namespace>
+# Then run it again with: kubectl create job --from=cronjob/<release>-clickhouse-retention
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "langfuse.fullname" . }}-clickhouse-retention-backfill
+  labels:
+    {{- include "langfuse.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "10"
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  backoffLimit: {{ .Values.clickhouse.retention.backoffLimit }}
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: clickhouse-materialize-ttl
+          image: {{ .Values.clickhouse.retention.image.repository }}:{{ .Values.clickhouse.retention.image.tag }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+
+              # 1) First apply the TTL (idempotent):
+              clickhouse-client \
+                --host="{{ include "langfuse.fullname" . }}-clickhouse" \
+                --port={{ .Values.clickhouse.nativePort }} \
+                --user={{ .Values.clickhouse.auth.username }} \
+                --password="$(CLICKHOUSE_PASSWORD)" \
+                --multiquery < /sql/retention.sql
+
+              # 2) MATERIALIZE TTL to immediately purge expired data:
+              clickhouse-client \
+                --host="{{ include "langfuse.fullname" . }}-clickhouse" \
+                --port={{ .Values.clickhouse.nativePort }} \
+                --user={{ .Values.clickhouse.auth.username }} \
+                --password="$(CLICKHOUSE_PASSWORD)" \
+                --mutations_sync=1 \
+                --query="ALTER TABLE default.traces MATERIALIZE TTL"
+
+              clickhouse-client \
+                --host="{{ include "langfuse.fullname" . }}-clickhouse" \
+                --port={{ .Values.clickhouse.nativePort }} \
+                --user={{ .Values.clickhouse.auth.username }} \
+                --password="$(CLICKHOUSE_PASSWORD)" \
+                --mutations_sync=1 \
+                --query="ALTER TABLE default.observations MATERIALIZE TTL"
+
+              clickhouse-client \
+                --host="{{ include "langfuse.fullname" . }}-clickhouse" \
+                --port={{ .Values.clickhouse.nativePort }} \
+                --user={{ .Values.clickhouse.auth.username }} \
+                --password="$(CLICKHOUSE_PASSWORD)" \
+                --mutations_sync=1 \
+                --query="ALTER TABLE default.scores MATERIALIZE TTL"
+
+              echo "OK: TTL materialized for traces, observations, and scores"
+          env:
+            - name: CLICKHOUSE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  {{- if .Values.clickhouse.auth.existingSecret }}
+                  name: {{ .Values.clickhouse.auth.existingSecret }}
+                  {{- else }}
+                  name: {{ include "langfuse.fullname" . }}-clickhouse
+                  {{- end }}
+                  key: {{ .Values.clickhouse.auth.existingSecretKey | default "clickhouse-password" }}
+          volumeMounts:
+            - name: sql
+              mountPath: /sql
+      volumes:
+        - name: sql
+          configMap:
+            name: {{ include "langfuse.fullname" . }}-clickhouse-retention-sql
+{{- end }}

--- a/charts/langfuse/values.yaml
+++ b/charts/langfuse/values.yaml
@@ -623,6 +623,26 @@ clickhouse:
   # -- The resources preset to use for the ClickHouse cluster.
   resourcesPreset: 2xlarge
 
+  # Data retention configuration for ClickHouse tables.
+  # Uses ClickHouse TTL to automatically purge old data.
+  retention:
+    # -- Enable ClickHouse data retention management via CronJob
+    enabled: false
+    # -- Number of days to keep data before deletion (default: 90 days = ~3 months)
+    ttlDays: 90
+    # -- Cron schedule for TTL re-application (default: daily at 3:00 AM)
+    schedule: "0 3 * * *"
+    # -- Number of completed jobs to keep in history
+    successfulJobsHistoryLimit: 3
+    # -- Number of failed jobs to keep in history
+    failedJobsHistoryLimit: 3
+    # -- Maximum number of retries for the job before marking as failed
+    backoffLimit: 2
+    # -- Image to use for running ClickHouse client commands
+    image:
+      repository: clickhouse/clickhouse-server
+      tag: "24.8"
+
 # S3/MinIO Configuration
 s3:
   # -- Enable MinIO deployment (via Bitnami Helm Chart). If you want to use a custom BlobStorage, e.g. S3, set to false.


### PR DESCRIPTION
## What does this PR do?

Adds automatic ClickHouse data retention management to the Langfuse Helm chart through configurable CronJob and Job resources.

### Problem

Langfuse stores traces, observations, and scores in ClickHouse tables. Over time, this data grows indefinitely, consuming storage and requiring manual intervention to manage. Users need a way to automatically purge old data beyond a configurable retention period.

### Solution

This PR introduces a new `clickhouse.retention` section that, when enabled, deploys:

1. **ConfigMap** — Contains an idempotent SQL script that sets TTL retention policies on the `traces`, `observations`, and `scores` tables. Safe to re-run on every Helm upgrade.

2. **CronJob** (`clickhouse-retention`) — Re-applies the TTL policy daily at a configurable time (default: 3:00 AM). Cost is negligible as it only updates metadata. ClickHouse automatically purges expired data during background merges.

3. **One-shot Job** (`clickhouse-retention-backfill`) — Runs on `post-install` / `post-upgrade` to immediately purge existing data older than the TTL. Without this, the TTL only applies to new data and cleanup of existing data happens gradually during background merges.

### Usage

Enable data retention in your `values.yaml`:

```yaml
clickhouse: retention:
    enabled: true
    ttlDays: 90          # Data older than 90 days will be deleted
    schedule: "0 3 * * *" # Daily at 3:00 AM
    image:
      repository: clickhouse/clickhouse-server
      tag: "24.8"


│ clickhouse.retention.enabled                    │ false                        │ Enable retention management              │
├─────────────────────────────────────────────────┼──────────────────────────────┼──────────────────────────────────────────┤
│ clickhouse.retention.ttlDays                    │ 90                           │ Days to keep data before deletion        │
├─────────────────────────────────────────────────┼──────────────────────────────┼──────────────────────────────────────────┤
│ clickhouse.retention.schedule                   │ "0 3 * * *"                  │ Cron schedule for TTL re-application     │
├─────────────────────────────────────────────────┼──────────────────────────────┼──────────────────────────────────────────┤
│ clickhouse.retention.successfulJobsHistoryLimit │ 3                            │ Completed jobs to keep in history        │
├─────────────────────────────────────────────────┼──────────────────────────────┼──────────────────────────────────────────┤
│ clickhouse.retention.failedJobsHistoryLimit     │ 3                            │ Failed jobs to keep in history           │
├─────────────────────────────────────────────────┼──────────────────────────────┼──────────────────────────────────────────┤
│ clickhouse.retention.backoffLimit               │ 2                            │ Max retries before marking job as failed │
├─────────────────────────────────────────────────┼──────────────────────────────┼──────────────────────────────────────────┤
│ clickhouse.retention.image.repository           │ clickhouse/clickhouse-server │ Client image repository                  │
├─────────────────────────────────────────────────┼──────────────────────────────┼──────────────────────────────────────────┤
│ clickhouse.retention.image.tag                  │ 24.8                         │ Client image tag                         │
└─────────────────────────────────────────────────┴──────────────────────────────┴──────────────────────────────────────────┘

```

### How it works

• The  ALTER TABLE ... MODIFY TTL  command is idempotent — adding the same TTL twice has no effect.
• ClickHouse handles the actual deletion during background merges, so the CronJob cost is minimal.
• The backfill Job uses  MATERIALIZE TTL  to force immediate purging of expired data on first run.

### Helm hooks

• ConfigMap + CronJob:  pre-install, pre-upgrade  (hook-weight: -10, 0)
• Backfill Job:  post-install, post-upgrade  (hook-weight: 10)
• All hooks use  hook-succeeded  deletion policy

### Files changed

•  charts/langfuse/templates/clickhouse-retention.yaml  — new Helm template
•  charts/langfuse/values.yaml  — added  clickhouse.retention  section with defaults