### PR TITLE
docs: fix OCI chart path in example guides and migration script

### DIFF
--- a/examples/minimal-installation/README.md
+++ b/examples/minimal-installation/README.md
@@ -50,13 +50,13 @@ kubectl apply -f secret.yaml -n langfuse
 2. Install the chart using the base values file and optional ingress configuration:
 ```bash
 # Basic installation
-helm install langfuse oci://ghcr.io/langfuse/langfuse-k8s/langfuse \
+helm install langfuse oci://ghcr.io/langfuse/langfuse-k8s/charts/langfuse \
   --version 2.0.0 \
   --namespace langfuse \
   -f values.yaml
 
 # Or with ingress enabled
-helm install langfuse oci://ghcr.io/langfuse/langfuse-k8s/langfuse \
+helm install langfuse oci://ghcr.io/langfuse/langfuse-k8s/charts/langfuse \
   --version 2.0.0 \
   --namespace langfuse \
   -f values.yaml -f with-ingress.yaml

--- a/examples/upgrade-v1-to-v2/README.md
+++ b/examples/upgrade-v1-to-v2/README.md
@@ -137,7 +137,7 @@ does.
 ### All stores external — in-place upgrade
 
 ```bash
-helm upgrade langfuse oci://ghcr.io/langfuse/langfuse-k8s/langfuse \
+helm upgrade langfuse oci://ghcr.io/langfuse/langfuse-k8s/charts/langfuse \
   --version 2.0.0 -n langfuse -f v2-inplace-values.yaml
 ```
 
@@ -148,7 +148,7 @@ Keep `*.deploy: false` and the existing host/auth fields. Service / Ingress name
 #### 1. Stand up v2 (no downtime)
 
 ```bash
-helm install langfuse-v2 oci://ghcr.io/langfuse/langfuse-k8s/langfuse \
+helm install langfuse-v2 oci://ghcr.io/langfuse/langfuse-k8s/charts/langfuse \
   --version 2.0.0 -n langfuse -f v2-values.yaml
 kubectl -n langfuse rollout status deploy/langfuse-v2-web --timeout=600s
 # Schema migrations are done; keep v1 as the only writer
@@ -234,7 +234,7 @@ kubectl -n langfuse rollout status deploy/langfuse-v2-web --timeout=300s
 
 ```bash
 kubectl -n langfuse delete ingress langfuse
-helm upgrade langfuse-v2 oci://ghcr.io/langfuse/langfuse-k8s/langfuse \
+helm upgrade langfuse-v2 oci://ghcr.io/langfuse/langfuse-k8s/charts/langfuse \
   --version 2.0.0 -n langfuse -f v2-app-values.yaml
 ```
 

--- a/examples/upgrade-v1-to-v2/scripts/migrate-v1-to-v2.sh
+++ b/examples/upgrade-v1-to-v2/scripts/migrate-v1-to-v2.sh
@@ -282,7 +282,7 @@ if [ -z "$CHART" ]; then
   if [ -f "$REPO_ROOT/charts/langfuse/Chart.yaml" ]; then
     CHART="$REPO_ROOT/charts/langfuse"
   else
-    CHART="oci://ghcr.io/langfuse/langfuse-k8s/langfuse"
+    CHART="oci://ghcr.io/langfuse/langfuse-k8s/charts/langfuse"
   fi
 fi
 


### PR DESCRIPTION
## Problem

The example guides and the v1→v2 migration script reference `oci://ghcr.io/langfuse/langfuse-k8s/langfuse`, which does not exist — ghcr.io returns **403 denied**. Anyone copy-pasting the install command from `examples/minimal-installation/README.md` fails at the main install step.

The chart is actually published at `oci://ghcr.io/langfuse/langfuse-k8s/charts/langfuse` (the path the root README already uses).

## Changes

- `examples/minimal-installation/README.md`: fix both install commands
- `examples/upgrade-v1-to-v2/README.md`: fix the in-place upgrade and sibling install/upgrade commands
- `examples/upgrade-v1-to-v2/scripts/migrate-v1-to-v2.sh`: fix the `CHART` fallback used when the script runs outside a repo checkout (runtime failure, not just docs)

## Verification

Ran the minimal-installation guide end to end on a fresh docker-desktop cluster (K8s v1.36.1, Helm v4.2.3): cert-manager v1.20.2 + clickhouse-operator 0.0.5 prerequisites, pre-created Secret, then `helm install --version 2.0.0` with `examples/minimal-installation/values.yaml` from the **corrected** OCI path. All pods reached Running, ClickHouseCluster/KeeperCluster CRs Ready, and `/api/public/health` + `/api/public/ready` returned `{"status":"OK","version":"4.4.0"}`. The old path was confirmed broken via `helm show chart` (403).

🤖 Generated with [Claude Code](https://claude.com/claude-code)