### PR TITLE
fix: guard app Secret lookup against missing .data

### DIFF
--- a/charts/langfuse/templates/langfuse-app-secret.yaml
+++ b/charts/langfuse/templates/langfuse-app-secret.yaml
@@ -18,10 +18,15 @@ encryptionKey, and nextauth.secret via value/secretKeyRef there.
 {{- $nextProvided := or .Values.langfuse.nextauth.secret.value (and .Values.langfuse.nextauth.secret.secretKeyRef.name .Values.langfuse.nextauth.secret.secretKeyRef.key) -}}
 {{- $name := include "langfuse.appSecretName" . -}}
 {{- $existing := lookup "v1" "Secret" .Release.Namespace $name -}}
+{{- /* A Secret stored with no keys has no .data field at all — e.g. the one
+this template creates when every credential is provided — so guard the index
+against nil or upgrades fail with "index of untyped nil". */ -}}
+{{- $existingData := dict -}}
+{{- if $existing -}}{{- $existingData = $existing.data | default dict -}}{{- end -}}
 {{- $data := dict -}}
 {{- range $key, $provided := dict "salt" $saltProvided "encryption-key" $encProvided "nextauth-secret" $nextProvided -}}
-  {{- if and $existing (index $existing.data $key) -}}
-    {{- $_ := set $data $key (index $existing.data $key) -}}
+  {{- if index $existingData $key -}}
+    {{- $_ := set $data $key (index $existingData $key) -}}
   {{- else if not $provided -}}
     {{- if eq $key "encryption-key" -}}
       {{- $_ := set $data $key (randAlphaNum 64 | sha256sum | b64enc) -}}

--- a/charts/langfuse/tests/langfuse-app-secret_test.yaml
+++ b/charts/langfuse/tests/langfuse-app-secret_test.yaml
@@ -59,6 +59,83 @@ tests:
           value: keep
         template: langfuse-app-secret.yaml
 
+  - it: should upgrade cleanly when the existing app secret has no data keys
+    values:
+      - ../values.lint.yaml
+    set:
+      langfuse.salt.value: "provided-salt"
+      langfuse.encryptionKey.value: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      langfuse.nextauth.secret.value: "provided-nextauth"
+    kubernetesProvider:
+      scheme:
+        "v1/Secret":
+          gvr:
+            version: "v1"
+            resource: "secrets"
+          namespaced: true
+      objects:
+        # What a provided-only install stores: the Secret exists but carries no
+        # .data field at all. The lookup-and-copy logic must tolerate that
+        # instead of failing the upgrade with "index of untyped nil".
+        - apiVersion: v1
+          kind: Secret
+          metadata:
+            name: RELEASE-NAME-langfuse-app
+            namespace: NAMESPACE
+          type: Opaque
+    asserts:
+      - hasDocuments:
+          count: 1
+        template: langfuse-app-secret.yaml
+      - notExists:
+          path: data.salt
+        template: langfuse-app-secret.yaml
+      - notExists:
+          path: data["encryption-key"]
+        template: langfuse-app-secret.yaml
+      - notExists:
+          path: data["nextauth-secret"]
+        template: langfuse-app-secret.yaml
+
+  - it: should preserve existing generated keys verbatim on upgrade
+    values:
+      - ../values.lint.yaml
+    set:
+      langfuse.salt.value: ""
+      langfuse.encryptionKey.value: ""
+      langfuse.nextauth.secret.value: ""
+    kubernetesProvider:
+      scheme:
+        "v1/Secret":
+          gvr:
+            version: "v1"
+            resource: "secrets"
+          namespaced: true
+      objects:
+        - apiVersion: v1
+          kind: Secret
+          metadata:
+            name: RELEASE-NAME-langfuse-app
+            namespace: NAMESPACE
+          type: Opaque
+          data:
+            salt: ZXhpc3Rpbmctc2FsdA==
+            encryption-key: ZXhpc3Rpbmcta2V5
+            nextauth-secret: ZXhpc3RpbmctbmV4dGF1dGg=
+    asserts:
+      - equal:
+          path: data.salt
+          value: ZXhpc3Rpbmctc2FsdA==
+        template: langfuse-app-secret.yaml
+      - equal:
+          path: data["encryption-key"]
+          value: ZXhpc3Rpbmcta2V5
+        template: langfuse-app-secret.yaml
+      - equal:
+          path: data["nextauth-secret"]
+          value: ZXhpc3RpbmctbmV4dGF1dGg=
+        template: langfuse-app-secret.yaml
+
   - it: should prefer an explicit secretKeyRef over the chart-managed app secret
     values:
       - ../values.lint.yaml


### PR DESCRIPTION
Fixes: https://github.com/langfuse/langfuse-k8s/issues/399

When `langfuse.salt`, `langfuse.encryptionKey`, and `langfuse.nextauth.secret` are all provided via value/secretKeyRef, the <release>-app Secret is rendered with no data keys and Kubernetes stores it without a .data field. On the next helm upgrade, lookup returns that Secret, $existing.data is nil, and templating fails:
```
langfuse-app-secret.yaml:23:24: error calling index: index of untyped nil
```
Because the Secret carries helm.sh/resource-policy: keep, it survives rollbacks and uninstalls, so every subsequent upgrade of a provided-only install fails until the Secret is deleted or patched manually - and a deleted Secret is recreated empty by the next successful upgrade, re-arming the failure.

The first install works only because and short-circuits on a nil $existing; once the empty Secret exists, $existing is truthy and index $existing.data $key hits nil.

This change resolves the existing Secret's data through a nil-safe dict before indexing, so provided-only installs upgrade cleanly. Per-key behavior is unchanged: values already stored in the cluster are still preserved verbatim, missing unprovided credentials are still generated.

Tested with `helm unittest`.