### PR TITLE
feature(v2-upgrade): Allow re-using the existing postgres disk on upgrade

### DIFF
--- a/examples/upgrade-v1-to-v2/README.md
+++ b/examples/upgrade-v1-to-v2/README.md
@@ -149,18 +149,29 @@ does.
 ### 0. Prerequisites
 
 1. Install cluster-wide **cert-manager** + **clickhouse-operator** (see [minimal-installation](../minimal-installation/)).
-2. Enable logical replication on **v1 Postgres** (Bitnami) and restart Postgres (or `helm upgrade` v1 once):
+2. **Postgres — pick one:**
+   - **Logical replication** (default, online copy): enable it on **v1 Postgres** (Bitnami) and restart Postgres (or `helm upgrade` v1 once):
 
-   ```yaml
-   postgresql:
-     primary:
-       extendedConfiguration: |
-         wal_level = logical
-         max_wal_senders = 10
-         max_replication_slots = 10
-   ```
+     ```yaml
+     postgresql:
+       primary:
+         extendedConfiguration: |
+           wal_level = logical
+           max_wal_senders = 10
+           max_replication_slots = 10
+     ```
 
-   Verify: `show wal_level;` → `logical`.
+     Verify: `show wal_level;` → `logical`.
+   - **Volume reuse** (same disk, downtime at freeze): skip `wal_level`. Confirm the Bitnami PVC, major version, and UID — the sibling overlay below must match:
+
+     ```bash
+     kubectl -n langfuse get pvc data-langfuse-postgresql-0
+     kubectl -n langfuse exec langfuse-postgresql-0 -- psql -U postgres -tAc 'SHOW server_version;'
+     kubectl -n langfuse get pod langfuse-postgresql-0 -o jsonpath='{.spec.containers[0].securityContext.runAsUser}{"\n"}'
+     kubectl -n langfuse exec langfuse-postgresql-0 -- printenv PGDATA
+     ```
+
+     Bitnami 1.5.x is typically Postgres **17**, UID **1001**, `PGDATA=/bitnami/postgresql/data` (so `settings.pgDir=data`). Pin `postgresql.image.tag` to `<major>-bookworm` (not `18`, and not plain `postgres:17`, which is Debian 13).
 3. Point the sibling at the **same** Langfuse app Secret as v1 (see [`v2-values.yaml`](./v2-values.yaml)).
    If that Secret is Helm-owned by v1, protect it: `kubectl annotate secret <name> helm.sh/resource-policy=keep`.
 4. Size `clickhouse.cluster.resources` in the sibling overlay for your data volume.
@@ -178,6 +189,8 @@ Keep `*.deploy: false` and the existing host/auth fields. Service / Ingress name
 
 #### 1. Stand up v2 (no downtime)
 
+**Logical replication** — empty sibling Postgres; schema init runs, then park the writers:
+
 ```bash
 helm install langfuse-v2 oci://ghcr.io/langfuse/langfuse-k8s/charts/langfuse \
   --version 2.0.0 -n langfuse -f v2-values.yaml
@@ -188,11 +201,110 @@ kubectl -n langfuse scale deploy/langfuse-v2-web deploy/langfuse-v2-worker --rep
 
 v1 keeps serving. Leave `langfuse.ingress.enabled: false` on the sibling so v1 keeps the domain.
 
+**Volume reuse** — do not create a new Postgres disk. Merge the overlay below with [`v2-values.yaml`](./v2-values.yaml) (set `auth.password` to the v1 superuser password, keep web/worker at 0). The sibling Postgres pod stays **Pending** on the RWO PVC until freeze. Skip waiting for `langfuse-v2-web` / `langfuse-v2-postgresql`. `langfuse.allowV1Upgrade` is required: the chart guard keys off the Bitnami PVC name and would otherwise refuse a deploy that still sees `data-langfuse-postgresql-0`.
+
+```yaml
+# postgres-reuse overlay (helm install ... -f v2-values.yaml -f this)
+langfuse:
+  allowV1Upgrade: true
+  replicas: 0
+  web:
+    replicas: 0
+  worker:
+    replicas: 0
+postgresql:
+  deploy: true
+  auth:
+    username: postgres          # v1 default
+    database: postgres_langfuse # v1 default
+    password: "<v1-superuser-password>"
+  image:
+    tag: "17-bookworm"
+  settings:
+    pgDir: data
+    existingSecret: langfuse-v2-postgresql-auth
+  userDatabase:
+    existingSecret: langfuse-v2-postgresql-auth
+  storage:
+    persistentVolumeClaimName: data-langfuse-postgresql-0
+  podSecurityContext:
+    fsGroup: 1001
+  securityContext:
+    runAsUser: 1001
+    runAsGroup: 1001
+    runAsNonRoot: true
+  extraInitContainers:
+    - name: bitnami-pgconf
+      image: docker.io/postgres:17-bookworm
+      imagePullPolicy: IfNotPresent
+      securityContext:
+        runAsUser: 1001
+        runAsGroup: 1001
+        runAsNonRoot: true
+        allowPrivilegeEscalation: false
+      command:
+        - sh
+        - -c
+        - |
+          set -e
+          DATA="/var/lib/postgresql/data/data"
+          if [ ! -f "$DATA/PG_VERSION" ]; then exit 0; fi
+          if [ ! -f "$DATA/postgresql.conf" ]; then
+            printf '%s\n' "listen_addresses = '*'" "port = 5432" \
+              "unix_socket_directories = '/tmp'" "password_encryption = scram-sha-256" \
+              > "$DATA/postgresql.conf"
+          fi
+          if [ ! -f "$DATA/pg_hba.conf" ]; then
+            printf '%s\n' "local   all  all                trust" \
+              "host    all  all  127.0.0.1/32  trust" \
+              "host    all  all  ::1/128       trust" \
+              "host    all  all  0.0.0.0/0     scram-sha-256" \
+              "host    all  all  ::/0          scram-sha-256" \
+              > "$DATA/pg_hba.conf"
+          fi
+      volumeMounts:
+        - name: postgres-data
+          mountPath: /var/lib/postgresql/data
+  customStartupProbe:
+    exec:
+      command: ["pg_isready", "-h", "127.0.0.1", "-U", "postgres"]
+    initialDelaySeconds: 10
+    timeoutSeconds: 5
+    periodSeconds: 10
+    failureThreshold: 30
+    successThreshold: 1
+  customLivenessProbe:
+    exec:
+      command: ["pg_isready", "-h", "127.0.0.1", "-U", "postgres"]
+    initialDelaySeconds: 10
+    timeoutSeconds: 5
+    periodSeconds: 10
+    failureThreshold: 3
+    successThreshold: 1
+  customReadinessProbe:
+    exec:
+      command: ["pg_isready", "-h", "127.0.0.1", "-U", "postgres"]
+    initialDelaySeconds: 10
+    timeoutSeconds: 5
+    periodSeconds: 10
+    failureThreshold: 3
+    successThreshold: 1
+```
+
+```bash
+helm install langfuse-v2 oci://ghcr.io/langfuse/langfuse-k8s/charts/langfuse \
+  --version 2.0.0 -n langfuse -f v2-values.yaml -f postgres-reuse.yaml
+```
+
+The init container writes `postgresql.conf` / `pg_hba.conf` into PGDATA — Bitnami keeps those files in the image, not on the PVC. Probes use `-U postgres` because UID 1001 has no passwd entry in the official image.
+
 #### 2. Online sync (no downtime)
 
-Run Postgres, object storage, and ClickHouse syncs in parallel.
+Run object storage and ClickHouse syncs in parallel. For Postgres, run **either** 2a **or** skip it (volume reuse has no online copy).
 
 ##### 2a. PostgreSQL — logical replication
+
+Skip this section if you chose volume reuse.
 
 ```bash
 kubectl -n langfuse exec langfuse-postgresql-0 -- \
@@ -249,7 +361,18 @@ kubectl -n langfuse scale deploy/langfuse-web --replicas=0
 kubectl -n langfuse scale deploy/langfuse-worker --replicas=0
 ```
 
-1. **Postgres** — confirm `lag_bytes=0`, then `DROP SUBSCRIPTION lf_sub;` on v2.
+1. **Postgres**
+   - **Logical replication:** confirm `lag_bytes=0`, then `DROP SUBSCRIPTION lf_sub;` on v2.
+   - **Volume reuse:** keep the disk, detach Bitnami, let the sibling attach:
+
+     ```bash
+     kubectl -n langfuse annotate pvc data-langfuse-postgresql-0 helm.sh/resource-policy=keep --overwrite
+     PV=$(kubectl -n langfuse get pvc data-langfuse-postgresql-0 -o jsonpath='{.spec.volumeName}')
+     kubectl patch pv "$PV" --type merge -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
+     kubectl -n langfuse scale sts/langfuse-postgresql --replicas=0
+     kubectl -n langfuse wait pod/langfuse-postgresql-0 --for=delete --timeout=180s
+     kubectl -n langfuse rollout status sts/langfuse-v2-postgresql --timeout=600s
+     ```
 2. **Object storage** — final `mc mirror` (no `--watch`).
 3. **ClickHouse** — `./ch-online-sync.sh --final`.
 
@@ -279,12 +402,20 @@ curl -s localhost:3000/api/public/ready
 ```
 
 Keep `langfuse` until you are confident, then `helm uninstall langfuse` and delete retained v1
-PVCs (`data-langfuse-postgresql-0`, …).
+PVCs (`data-langfuse-postgresql-0`, …). **Volume reuse:** do **not** delete `data-langfuse-postgresql-0`
+— the sibling Postgres is using it.
 
 #### Rollback
 
 Until v1 is uninstalled, abort by stopping the sync loops and scaling v1 writers back up. If the
 v1 Ingress was already deleted, restore it from the v1 release before sending traffic back.
+
+**Volume reuse:** scale the sibling Postgres off the disk before bringing Bitnami back:
+
+```bash
+kubectl -n langfuse scale sts/langfuse-v2-postgresql --replicas=0
+kubectl -n langfuse scale sts/langfuse-postgresql --replicas=1
+```
 
 ---
 

--- a/examples/upgrade-v1-to-v2/README.md
+++ b/examples/upgrade-v1-to-v2/README.md
@@ -64,11 +64,13 @@ Useful flags: `--namespace`, `--source-release`, `--target-release` (default `<s
 `--output-values`, `--output-cutover-values`, `--extra-values` (repeatable), `--context`,
 `--image-tag` (defaults to the v1 Helm `appVersion` / values tag), `--skip-prereqs`,
 `--worker-drain-seconds` (max wait for v1 Redis queues after web scale-down), `--force`
-(continue after lag / readiness / queue-drain failures). Helm **≥ 3.17** is required.
+(continue after lag / readiness / queue-drain failures), `--postgres-mode` (`logical`
+default, or `reuse-volume` to attach the Bitnami Postgres PVC to the sibling). Helm
+**≥ 3.17** is required.
 
 | `*.deploy` | Action |
 |------------|--------|
-| `postgresql.deploy: true` | Enable logical replication on v1, subscribe the sibling, drop subscription at freeze |
+| `postgresql.deploy: true` | **logical** (default): enable logical replication on v1, subscribe the sibling, drop subscription at freeze. **reuse-volume**: scale v1 Postgres to 0 and mount `data-<release>-postgresql-0` on the sibling (see below) |
 | `clickhouse.deploy: true` | Incremental `remote()` copy via [`ch-online-sync.sh`](./scripts/ch-online-sync.sh) |
 | `s3.deploy: true` | `mc mirror` MinIO → SeaweedFS (in-cluster `minio/mc` pod) |
 | `redis.deploy: true` | Stand up empty Valkey on the sibling (queue/cache; no data copy) |
@@ -85,13 +87,42 @@ Generated overlays:
 
 | Store | Online (v1 live) | Freeze delta |
 |-------|------------------|--------------|
-| **Postgres** | Logical replication (initial copy + WAL streaming) | Wait `lag_bytes=0`, drop subscription |
+| **Postgres** (logical) | Logical replication (initial copy + WAL streaming) | Wait `lag_bytes=0`, drop subscription |
+| **Postgres** (`reuse-volume`) | Sibling pod Pending on the Bitnami PVC | Scale v1 Postgres to 0, sibling attaches the same disk |
 | **Object storage (MinIO → SeaweedFS)** | `mc mirror` / `mc mirror --watch` | Final `mc mirror` (new blobs only) |
 | **ClickHouse** | `remote()` INSERT…SELECT with an `event_ts` watermark loop | Final watermark pass (no `OPTIMIZE FINAL` by default) |
 | **Redis / Valkey** | — (ephemeral queue/cache) | — |
 
 Downtime ≈ freeze writers + drain v1 worker queue + final deltas + traffic shift.
 The multi-hour bulk copy runs **outside** the freeze window.
+
+### Postgres `--postgres-mode reuse-volume`
+
+Opt-in alternative to logical replication when you prefer to keep the Bitnami disk
+instead of copying it. The sibling is installed with
+`postgresql.storage.persistentVolumeClaimName` pointing at `data-<source>-postgresql-0`.
+The v2 pod stays **Pending** on that RWO volume until freeze, when v1 Postgres is scaled
+to 0 and the sibling starts from the same files.
+
+```bash
+./migrate-v1-to-v2.sh --values /path/to/your-v1-values.yaml --postgres-mode reuse-volume
+```
+
+The script pins `postgresql.image.tag` to `<major>-bookworm` (Bitnami 1.5.x is
+Postgres 17 on Debian 12; `postgres:17` is currently Debian 13 and would warn about
+a glibc collation version mismatch). It sets `settings.pgDir=data` (Bitnami PGDATA
+is `<volume>/data`, not groundhog2k's `pg/`), copies the v1 password / database /
+username, runs as the Bitnami UID (usually 1001), and writes `postgresql.conf` /
+`pg_hba.conf` into PGDATA on first start — Bitnami keeps those files in the image,
+not on the PVC. Generated overlays set `langfuse.allowV1Upgrade: true` because the
+chart's v1 guard keys off the Bitnami PVC name (`data-<release>-postgresql-0`) vs
+the empty v2 claim (`postgres-data-<release>-postgresql-0`), and reuse-volume keeps
+the former. Rollback is scale v2 Postgres to 0, then v1 Postgres back to 1 — do
+**not** delete the PVC.
+
+Trade-offs vs logical replication: no online copy and no extra disk, but Postgres is
+unavailable for the freeze window, majors cannot be jumped, and the sibling keeps using
+the v1 PVC name (`helm uninstall` of v1 must retain it).
 
 ## Naming (sibling path)
 

--- a/examples/upgrade-v1-to-v2/README.md
+++ b/examples/upgrade-v1-to-v2/README.md
@@ -88,7 +88,7 @@ Generated overlays:
 | Store | Online (v1 live) | Freeze delta |
 |-------|------------------|--------------|
 | **Postgres** (logical) | Logical replication (initial copy + WAL streaming) | Wait `lag_bytes=0`, drop subscription |
-| **Postgres** (`reuse-volume`) | Sibling pod Pending on the Bitnami PVC | Scale v1 Postgres to 0, sibling attaches the same disk |
+| **Postgres** (`reuse-volume`) | Sibling unschedulable (anti-affinity vs v1 Postgres pod) | Scale v1 Postgres to 0, sibling attaches the same disk |
 | **Object storage (MinIO → SeaweedFS)** | `mc mirror` / `mc mirror --watch` | Final `mc mirror` (new blobs only) |
 | **ClickHouse** | `remote()` INSERT…SELECT with an `event_ts` watermark loop | Final watermark pass (no `OPTIMIZE FINAL` by default) |
 | **Redis / Valkey** | — (ephemeral queue/cache) | — |
@@ -101,8 +101,15 @@ The multi-hour bulk copy runs **outside** the freeze window.
 Opt-in alternative to logical replication when you prefer to keep the Bitnami disk
 instead of copying it. The sibling is installed with
 `postgresql.storage.persistentVolumeClaimName` pointing at `data-<source>-postgresql-0`.
-The v2 pod stays **Pending** on that RWO volume until freeze, when v1 Postgres is scaled
-to 0 and the sibling starts from the same files.
+`ReadWriteOnce` is per-node, not per-pod, so the overlay also sets a **required**
+pod anti-affinity against the v1 Postgres pod (`statefulset.kubernetes.io/pod-name`).
+That keeps the sibling off the node that still holds the volume until freeze scales
+v1 Postgres to 0. The existing PVC access mode is left unchanged (`ReadWriteOncePod`
+cannot be patched onto a bound claim).
+
+If the sibling release was already installed with logical replication (its own
+`volumeClaimTemplates` volume), uninstall it and re-run — Helm cannot switch an
+existing StatefulSet onto the Bitnami PVC.
 
 ```bash
 ./migrate-v1-to-v2.sh --values /path/to/your-v1-values.yaml --postgres-mode reuse-volume
@@ -171,7 +178,7 @@ does.
      kubectl -n langfuse exec langfuse-postgresql-0 -- printenv PGDATA
      ```
 
-     Bitnami 1.5.x is typically Postgres **17**, UID **1001**, `PGDATA=/bitnami/postgresql/data` (so `settings.pgDir=data`). Pin `postgresql.image.tag` to `<major>-bookworm` (not `18`, and not plain `postgres:17`, which is Debian 13).
+     Bitnami 1.5.x is typically Postgres **17**, UID **1001**, `PGDATA=/bitnami/postgresql/data` (so `settings.pgDir=data`). Pin `postgresql.image.tag` to `<major>-bookworm` (not `18`, and not plain `postgres:17`, which is Debian 13). If `PGDATA` is empty or not under the `data` volume mount, stop — do not guess `pgDir`.
 3. Point the sibling at the **same** Langfuse app Secret as v1 (see [`v2-values.yaml`](./v2-values.yaml)).
    If that Secret is Helm-owned by v1, protect it: `kubectl annotate secret <name> helm.sh/resource-policy=keep`.
 4. Size `clickhouse.cluster.resources` in the sibling overlay for your data volume.
@@ -201,7 +208,7 @@ kubectl -n langfuse scale deploy/langfuse-v2-web deploy/langfuse-v2-worker --rep
 
 v1 keeps serving. Leave `langfuse.ingress.enabled: false` on the sibling so v1 keeps the domain.
 
-**Volume reuse** — do not create a new Postgres disk. Merge the overlay below with [`v2-values.yaml`](./v2-values.yaml) (set `auth.password` to the v1 superuser password, keep web/worker at 0). The sibling Postgres pod stays **Pending** on the RWO PVC until freeze. Skip waiting for `langfuse-v2-web` / `langfuse-v2-postgresql`. `langfuse.allowV1Upgrade` is required: the chart guard keys off the Bitnami PVC name and would otherwise refuse a deploy that still sees `data-langfuse-postgresql-0`.
+**Volume reuse** — do not create a new Postgres disk. Merge the overlay below with [`v2-values.yaml`](./v2-values.yaml) (set `auth.password` to the v1 superuser password, keep web/worker at 0). Required anti-affinity against `langfuse-postgresql-0` keeps the sibling **Pending** until freeze (ReadWriteOnce is per-node; do not change the PVC to ReadWriteOncePod). Skip waiting for `langfuse-v2-web` / `langfuse-v2-postgresql`. `langfuse.allowV1Upgrade` is required: the chart guard keys off the Bitnami PVC name and would otherwise refuse a deploy that still sees `data-langfuse-postgresql-0`. If a sibling from logical replication already exists, `helm uninstall langfuse-v2` first — the STS cannot switch from `volumeClaimTemplates` to this PVC.
 
 ```yaml
 # postgres-reuse overlay (helm install ... -f v2-values.yaml -f this)
@@ -233,6 +240,13 @@ postgresql:
     runAsUser: 1001
     runAsGroup: 1001
     runAsNonRoot: true
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              statefulset.kubernetes.io/pod-name: langfuse-postgresql-0
+          topologyKey: kubernetes.io/hostname
   extraInitContainers:
     - name: bitnami-pgconf
       image: docker.io/postgres:17-bookworm
@@ -248,7 +262,10 @@ postgresql:
         - |
           set -e
           DATA="/var/lib/postgresql/data/data"
-          if [ ! -f "$DATA/PG_VERSION" ]; then exit 0; fi
+          if [ ! -f "$DATA/PG_VERSION" ]; then
+            echo "bitnami-pgconf: no PG_VERSION in $DATA (wrong pgDir? refusing to initdb an empty cluster)"
+            exit 1
+          fi
           if [ ! -f "$DATA/postgresql.conf" ]; then
             printf '%s\n' "listen_addresses = '*'" "port = 5432" \
               "unix_socket_directories = '/tmp'" "password_encryption = scram-sha-256" \
@@ -296,7 +313,7 @@ helm install langfuse-v2 oci://ghcr.io/langfuse/langfuse-k8s/charts/langfuse \
   --version 2.0.0 -n langfuse -f v2-values.yaml -f postgres-reuse.yaml
 ```
 
-The init container writes `postgresql.conf` / `pg_hba.conf` into PGDATA — Bitnami keeps those files in the image, not on the PVC. Probes use `-U postgres` because UID 1001 has no passwd entry in the official image.
+The init container writes `postgresql.conf` / `pg_hba.conf` into PGDATA — Bitnami keeps those files in the image, not on the PVC. A missing `PG_VERSION` is fatal so the official entrypoint cannot `initdb` an empty cluster. Probes use `-U postgres` because UID 1001 has no passwd entry in the official image.
 
 #### 2. Online sync (no downtime)
 

--- a/examples/upgrade-v1-to-v2/scripts/migrate-v1-to-v2.sh
+++ b/examples/upgrade-v1-to-v2/scripts/migrate-v1-to-v2.sh
@@ -29,6 +29,11 @@ MC_IMAGE="${MC_IMAGE:-minio/mc:latest}"
 IMAGE_TAG="${IMAGE_TAG:-}"
 MC_POD=""
 RESUME_TARGET=0
+PG_MODE="${PG_MODE:-logical}"
+PG_REUSE_PVC=""
+PG_REUSE_IMAGE_TAG=""
+PG_REUSE_UID=1001
+PG_REUSE_PGDIR="data"
 
 usage() {
   cat <<'EOF'
@@ -61,6 +66,9 @@ Options:
       --dry-run             Preflight + plan + generate values; do not change the cluster
       --skip-prereqs        Do not install cert-manager / ClickHouse operator
       --worker-drain-seconds N  Max seconds to wait for v1 Redis queues after scaling web down (default: 60)
+      --postgres-mode MODE  logical (default): replicate into a new volume.
+                            reuse-volume: scale down Bitnami Postgres and mount
+                            its PVC on the sibling groundhog2k Postgres
   -h, --help                Show this help
 
 Environment: KUBECTL, HELM, KCTX, NAMESPACE, WORKER_DRAIN_SECONDS, MC_IMAGE, IMAGE_TAG
@@ -241,6 +249,7 @@ while [ $# -gt 0 ]; do
     --worker-drain-seconds) WORKER_DRAIN_SECONDS=$2; shift 2 ;;
     --image-tag) IMAGE_TAG=$2; shift 2 ;;
     --force) FORCE=1; shift ;;
+    --postgres-mode) PG_MODE=$2; shift 2 ;;
     -h|--help) usage; exit 0 ;;
     *) die "unknown option: $1" ;;
   esac
@@ -248,6 +257,10 @@ done
 
 [ -n "$VALUES_FILE" ] || { usage >&2; die "--values is required"; }
 [ -f "$VALUES_FILE" ] || die "values file not found: $VALUES_FILE"
+case "$PG_MODE" in
+  logical|reuse-volume) ;;
+  *) die "--postgres-mode must be 'logical' or 'reuse-volume' (got $PG_MODE)" ;;
+esac
 OUTPUT_VALUES=${OUTPUT_VALUES:-$PWD/v2-values.generated.yaml}
 OUTPUT_CUTOVER_VALUES=${OUTPUT_CUTOVER_VALUES:-$PWD/v2-cutover-values.generated.yaml}
 
@@ -287,7 +300,7 @@ if [ -z "$CHART" ]; then
 fi
 
 V1_JSON=$(yaml_to_json "$VALUES_FILE")
-PLAN_JSON=$(printf '%s' "$V1_JSON" | python3 "$VALUES_MIGRATE" --plan --input -)
+PLAN_JSON=$(printf '%s' "$V1_JSON" | python3 "$VALUES_MIGRATE" --plan --input - --postgres-mode "$PG_MODE")
 PG_ON=0; CH_ON=0; REDIS_ON=0; S3_ON=0; INGRESS_VALUES=0
 printf '%s' "$PLAN_JSON" | jq -e '.postgresql == true' >/dev/null && PG_ON=1
 printf '%s' "$PLAN_JSON" | jq -e '.clickhouse == true' >/dev/null && CH_ON=1
@@ -356,6 +369,7 @@ V2_WORKER="${TGT_FULLNAME}-worker"
 V1_INGRESS="$SRC_FULLNAME"
 
 V1_PG_DB=$(printf '%s' "$V1_JSON" | jq -r '.postgresql.auth.database // "postgres_langfuse"')
+V1_PG_USER=$(printf '%s' "$V1_JSON" | jq -r '.postgresql.auth.username // "postgres"')
 V1_PG_SECRET=$(printf '%s' "$V1_JSON" | jq -r '.postgresql.auth.existingSecret // empty')
 V1_PG_SECRET=${V1_PG_SECRET:-${SRC_FULLNAME}-postgresql}
 V1_PG_PW_KEY=$(printf '%s' "$V1_JSON" | jq -r '.postgresql.auth.secretKeys.adminPasswordKey // .postgresql.auth.secretKeys.userPasswordKey // "postgres-password"')
@@ -379,6 +393,48 @@ v1_pg_super() {
   kx -n "$NAMESPACE" exec "${SRC_FULLNAME}-postgresql-0" -- env PGPASSWORD="$pw" psql -U postgres "$@"
 }
 
+detect_postgres_reuse() {
+  local pod="${SRC_FULLNAME}-postgresql-0"
+  local ver pgdata mount rel uid
+  PG_REUSE_PVC="data-${SRC_FULLNAME}-postgresql-0"
+  kx -n "$NAMESPACE" get pvc "$PG_REUSE_PVC" >/dev/null \
+    || die "reuse-volume: PVC $PG_REUSE_PVC not found"
+  kx -n "$NAMESPACE" get pod "$pod" >/dev/null \
+    || die "reuse-volume: pod $pod not found (v1 Postgres must be running so we can read version/UID/PGDATA)"
+  ver=$(v1_pg_super -d postgres -tAc "SHOW server_version;" | tr -d '[:space:]')
+  [ -n "$ver" ] || die "reuse-volume: could not read v1 server_version"
+  PG_REUSE_IMAGE_TAG=${ver%%.*}
+  [[ "$PG_REUSE_IMAGE_TAG" =~ ^[0-9]+$ ]] || die "reuse-volume: unexpected server_version '$ver'"
+  # Bitnami 1.5.x is Debian 12; pin bookworm so glibc matches (see migrate-values.py).
+  PG_REUSE_IMAGE_TAG="${PG_REUSE_IMAGE_TAG}-bookworm"
+  uid=$(kx -n "$NAMESPACE" get pod "$pod" -o jsonpath='{.spec.containers[0].securityContext.runAsUser}')
+  [ -n "$uid" ] || uid=$(kx -n "$NAMESPACE" get pod "$pod" -o jsonpath='{.spec.securityContext.runAsUser}')
+  [ -n "$uid" ] || uid=1001
+  PG_REUSE_UID=$uid
+  pgdata=$(kx -n "$NAMESPACE" exec "$pod" -- printenv PGDATA | tr -d '[:space:]' || true)
+  mount=$(kx -n "$NAMESPACE" get pod "$pod" -o jsonpath='{range .spec.containers[0].volumeMounts[*]}{.name}{"\t"}{.mountPath}{"\n"}{end}' \
+    | awk -F'\t' '$1=="data"{print $2; exit}')
+  if [ -n "$pgdata" ] && [ -n "$mount" ]; then
+    rel=${pgdata#"$mount"/}
+    if [ "$rel" != "$pgdata" ] && [ -n "$rel" ]; then
+      PG_REUSE_PGDIR=$rel
+    fi
+  fi
+  log "postgres volume reuse: pvc=$PG_REUSE_PVC  image=postgres:$PG_REUSE_IMAGE_TAG  uid=$PG_REUSE_UID  pgDir=$PG_REUSE_PGDIR  (v1 server_version=$ver)"
+}
+
+retain_postgres_volume() {
+  local pvc=$PG_REUSE_PVC pv
+  kx -n "$NAMESPACE" annotate pvc "$pvc" helm.sh/resource-policy=keep --overwrite
+  kx -n "$NAMESPACE" patch "sts/${SRC_FULLNAME}-postgresql" --type merge -p \
+    '{"spec":{"persistentVolumeClaimRetentionPolicy":{"whenDeleted":"Retain","whenScaled":"Retain"}}}' \
+    >/dev/null 2>&1 || true
+  pv=$(kx -n "$NAMESPACE" get pvc "$pvc" -o jsonpath='{.spec.volumeName}')
+  [ -n "$pv" ] || die "PVC $pvc has no bound PersistentVolume"
+  kx patch pv "$pv" --type merge -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}' >/dev/null
+  log "retained PV/$pv via PVC $pvc (will not delete on v1 uninstall / scale-down)"
+}
+
 # Chart Ingress is swapped automatically when values enable it, or when the
 # existing Ingress is owned by the v1 Helm release. Anything else is treated
 # as externally managed — the script asks you to retarget it.
@@ -391,6 +447,10 @@ if kx -n "$NAMESPACE" get ingress "$V1_INGRESS" >/dev/null 2>&1; then
     warn "Ingress/$V1_INGRESS exists but is not owned by release $SOURCE_RELEASE — treating it as externally managed; you will need to retarget it at $V2_WEB"
   fi
 fi
+
+V1_WEB_HAD_REPLICAS=0
+V1_WEB_REPLICAS=$(kx -n "$NAMESPACE" get deploy "${SRC_FULLNAME}-web" -o jsonpath='{.spec.replicas}' 2>/dev/null || echo 0)
+[ "${V1_WEB_REPLICAS:-0}" != "0" ] && V1_WEB_HAD_REPLICAS=1
 
 V1_MARKERS=0
 EXPECTED_MARKERS=0
@@ -424,6 +484,14 @@ elif [ "$V1_MARKERS" -eq 0 ]; then
   die "no v1 Bitnami resources found for bundled stores on release $SOURCE_RELEASE (looked for ClickHouse STS ${SRC_FULLNAME}-clickhouse-shard0, PVC data-${SRC_FULLNAME}-postgresql-0, and/or Deployment ${SRC_FULLNAME}-s3). Wrong context or already migrated?"
 fi
 
+if [ "$PG_MODE" = "reuse-volume" ]; then
+  [ "$PG_ON" -eq 1 ] || die "--postgres-mode reuse-volume requires postgresql.deploy=true"
+  detect_postgres_reuse
+  POSTGRES_REUSE_PASSWORD=$(secret_data "$NAMESPACE" "$V1_PG_SECRET" "$V1_PG_PW_KEY")
+  [ -n "$POSTGRES_REUSE_PASSWORD" ] || die "reuse-volume: could not read v1 Postgres password from Secret/$V1_PG_SECRET key $V1_PG_PW_KEY"
+  export POSTGRES_REUSE_PASSWORD
+fi
+
 if [ "$NEED_STORES" -eq 1 ] && hx status "$TARGET_RELEASE" -n "$NAMESPACE" >/dev/null 2>&1; then
   warn "target release $TARGET_RELEASE already exists — later steps will reuse it"
 fi
@@ -434,6 +502,17 @@ write_values() {
   local extra=()
   if [ "$mode" != "inplace" ]; then
     extra+=(--target-fullname "$TGT_FULLNAME")
+  fi
+  if [ "$PG_MODE" = "reuse-volume" ] && [ "$PG_ON" -eq 1 ]; then
+    extra+=(
+      --postgres-mode reuse-volume
+      --postgres-pvc "$PG_REUSE_PVC"
+      --postgres-image-tag "$PG_REUSE_IMAGE_TAG"
+      --postgres-username "$V1_PG_USER"
+      --postgres-database "$V1_PG_DB"
+      --postgres-run-as-user "$PG_REUSE_UID"
+      --postgres-pg-dir "$PG_REUSE_PGDIR"
+    )
   fi
   # Feed the JSON converted by yaml_to_json (like the --plan call) so the
   # yq/PyYAML/Ruby fallback chain holds — migrate-values.py itself can only
@@ -494,7 +573,7 @@ Migration plan (from values; deploy defaults to true when unset)
   context:          $CTX_NAME
   source release:   $SOURCE_RELEASE  (fullname $SRC_FULLNAME)
   target release:   $([ "$NEED_STORES" -eq 1 ] && echo "$TARGET_RELEASE  (fullname $TGT_FULLNAME)" || echo "(in-place upgrade of $SOURCE_RELEASE)")
-  postgresql:       $([ "$PG_ON" -eq 1 ] && echo "migrate (logical replication)" || echo "skip (external / deploy=false)")
+  postgresql:       $([ "$PG_ON" -eq 1 ] && { [ "$PG_MODE" = "reuse-volume" ] && echo "migrate (reuse Bitnami PVC $PG_REUSE_PVC, postgres:$PG_REUSE_IMAGE_TAG)" || echo "migrate (logical replication)"; } || echo "skip (external / deploy=false)")
   clickhouse:       $([ "$CH_ON" -eq 1 ] && echo "migrate (remote() watermark sync)" || echo "skip (external / deploy=false)")
   object storage:   $([ "$S3_ON" -eq 1 ] && echo "migrate (mc mirror MinIO → SeaweedFS)" || echo "skip (external / deploy=false)")
   redis/valkey:     $([ "$REDIS_ON" -eq 1 ] && echo "redeploy empty (ephemeral; no data copy)" || echo "skip (external / deploy=false)")
@@ -577,7 +656,7 @@ EOF
 fi
 
 # --- 4b. Enable logical replication on v1 Postgres --------------------------
-if [ "$PG_ON" -eq 1 ]; then
+if [ "$PG_ON" -eq 1 ] && [ "$PG_MODE" = "logical" ]; then
   WAL=$(v1_pg_super -d postgres -tAc "SHOW wal_level;" | tr -d '[:space:]' || true)
   if [ "$WAL" != "logical" ]; then
     confirm "Enable wal_level=logical on v1 Postgres (ALTER SYSTEM + StatefulSet restart)?"
@@ -589,6 +668,8 @@ if [ "$PG_ON" -eq 1 ]; then
   else
     log "v1 Postgres already has wal_level=logical"
   fi
+elif [ "$PG_ON" -eq 1 ]; then
+  log "postgres volume reuse: skipping wal_level=logical (no replication)"
 fi
 
 # --- 5. Stand up sibling v2 -------------------------------------------------
@@ -610,7 +691,10 @@ else
   require_sibling_store deploy "$V2_WEB"
 fi
 
-[ "$PG_ON" -eq 1 ] && wait_sts "${TGT_FULLNAME}-postgresql"
+[ "$PG_ON" -eq 1 ] && [ "$PG_MODE" != "reuse-volume" ] && wait_sts "${TGT_FULLNAME}-postgresql"
+if [ "$PG_ON" -eq 1 ] && [ "$PG_MODE" = "reuse-volume" ]; then
+  log "postgres volume reuse: sibling STS ${TGT_FULLNAME}-postgresql will stay Pending until v1 releases PVC $PG_REUSE_PVC"
+fi
 [ "$REDIS_ON" -eq 1 ] && {
   if kx -n "$NAMESPACE" get sts "${TGT_FULLNAME}-redis" >/dev/null 2>&1; then
     wait_sts "${TGT_FULLNAME}-redis"
@@ -633,6 +717,8 @@ if [ "${V2_WEB_REPLICAS:-0}" != "0" ]; then
   log "scaling $V2_WEB / $V2_WORKER to 0 after schema init (v1 stays the writer)"
   kx -n "$NAMESPACE" scale deploy/"$V2_WEB" --replicas=0
   kx -n "$NAMESPACE" scale deploy/"$V2_WORKER" --replicas=0 >/dev/null 2>&1 || true
+elif [ "$PG_MODE" = "reuse-volume" ]; then
+  log "$V2_WEB is at 0 replicas until the reused Postgres volume is attached at freeze"
 else
   log "$V2_WEB is already at 0 replicas — assuming schema init completed on a previous run"
 fi
@@ -657,7 +743,7 @@ pg_exec_v2() {
   kx -n "$NAMESPACE" exec -i "${TGT_FULLNAME}-postgresql-0" -- env PGPASSWORD="$su_pw" psql -U postgres -d "$V2_PG_DB" "$@"
 }
 
-if [ "$PG_ON" -eq 1 ]; then
+if [ "$PG_ON" -eq 1 ] && [ "$PG_MODE" = "logical" ]; then
   confirm "Start PostgreSQL logical replication (publication on v1, subscription on v2)?"
   SU_PW=$(secret_data "$NAMESPACE" "$V2_PG_SECRET" POSTGRES_PASSWORD)
   V1_PW=$(secret_data "$NAMESPACE" "$V1_PG_SECRET" "$V1_PG_PW_KEY")
@@ -684,6 +770,8 @@ if [ "$PG_ON" -eq 1 ]; then
     pg_exec_v1 -c "SELECT application_name, state, pg_wal_lsn_diff(pg_current_wal_lsn(), replay_lsn) AS lag_bytes FROM pg_stat_replication;" || true
     sleep 3
   done
+elif [ "$PG_ON" -eq 1 ]; then
+  log "postgres volume reuse: no logical replication; sibling will take over PVC $PG_REUSE_PVC at freeze"
 fi
 
 ensure_mc_pod() {
@@ -817,10 +905,21 @@ drain_v1_queues() {
 confirm "FREEZE window: scale down v1 web (then worker) and run final deltas? This starts application downtime."
 
 kx -n "$NAMESPACE" scale deploy/"${SRC_FULLNAME}-web" --replicas=0
-drain_v1_queues
-kx -n "$NAMESPACE" scale deploy/"${SRC_FULLNAME}-worker" --replicas=0
+if [ "$V1_WEB_HAD_REPLICAS" -eq 1 ]; then
+  drain_v1_queues
+else
+  log "v1 web was already at 0 replicas — skipping queue drain"
+fi
+kx -n "$NAMESPACE" scale deploy/"${SRC_FULLNAME}-worker" --replicas=0 >/dev/null 2>&1 || true
 
-if [ "$PG_ON" -eq 1 ]; then
+if [ "$PG_ON" -eq 1 ] && [ "$PG_MODE" = "reuse-volume" ]; then
+  confirm "Detach Bitnami Postgres from PVC $PG_REUSE_PVC and start sibling Postgres on that volume?"
+  retain_postgres_volume
+  log "scaling ${SRC_FULLNAME}-postgresql to 0 (releases the RWO volume)"
+  kx -n "$NAMESPACE" scale "sts/${SRC_FULLNAME}-postgresql" --replicas=0
+  kx -n "$NAMESPACE" wait pod "${SRC_FULLNAME}-postgresql-0" --for=delete --timeout=180s || true
+  wait_sts "${TGT_FULLNAME}-postgresql"
+elif [ "$PG_ON" -eq 1 ]; then
   log "waiting for Postgres lag_bytes=0"
   SU_PW=$(secret_data "$NAMESPACE" "$V2_PG_SECRET" POSTGRES_PASSWORD)
   for i in $(seq 1 60); do
@@ -846,6 +945,9 @@ if [ "$CH_ON" -eq 1 ]; then
 fi
 
 # --- 8. Bring v2 writers up, then shift traffic -----------------------------
+if [ "$V1_WEB_HAD_REPLICAS" -eq 0 ]; then
+  log "v1 web was at 0 replicas — leaving $V2_WEB scaled down (stores migrated; no traffic shift)"
+else
 log "scaling $V2_WEB / $V2_WORKER up"
 kx -n "$NAMESPACE" scale deploy/"$V2_WEB" --replicas=1
 kx -n "$NAMESPACE" scale deploy/"$V2_WORKER" --replicas=1 >/dev/null 2>&1 || true
@@ -879,6 +981,7 @@ READY=$(kx -n "$NAMESPACE" run "${TGT_FULLNAME}-ready-check" --rm -i --restart=N
   curl -sf "http://${V2_WEB}.${NAMESPACE}.svc.cluster.local:3000/api/public/ready" || true)
 log "v2 readiness: ${READY:-<empty>}"
 [ -n "$READY" ] || fail_or_force "v2 readiness check failed for Service/$V2_WEB"
+fi
 
 cat <<EOF
 
@@ -889,10 +992,11 @@ v2 is release $TARGET_RELEASE (Service $V2_WEB). v1 ($SOURCE_RELEASE) is scaled 
 Next (manual):
   1. Keep $SOURCE_RELEASE until you are confident
   2. helm uninstall $SOURCE_RELEASE -n $NAMESPACE
-  3. Delete retained v1 Bitnami PVCs (data-${SRC_FULLNAME}-postgresql-0, …)
+$([ "$PG_MODE" = "reuse-volume" ] && echo "  3. Do NOT delete PVC data-${SRC_FULLNAME}-postgresql-0 — the sibling Postgres is using it" || echo "  3. Delete retained v1 Bitnami PVCs (data-${SRC_FULLNAME}-postgresql-0, …)")
 
 Rollback before uninstalling v1: scale v1 writers back up
   kubectl -n $NAMESPACE scale deploy/${SRC_FULLNAME}-web deploy/${SRC_FULLNAME}-worker --replicas=1
+$([ "$PG_MODE" = "reuse-volume" ] && echo "  kubectl -n $NAMESPACE scale sts/${TGT_FULLNAME}-postgresql --replicas=0 && kubectl -n $NAMESPACE scale sts/${SRC_FULLNAME}-postgresql --replicas=1")
 $([ "$INGRESS_ON" -eq 1 ] && echo "  (re-create Ingress/$V1_INGRESS from the v1 release if you already deleted it)")
 
 Generated values:

--- a/examples/upgrade-v1-to-v2/scripts/migrate-v1-to-v2.sh
+++ b/examples/upgrade-v1-to-v2/scripts/migrate-v1-to-v2.sh
@@ -34,6 +34,7 @@ PG_REUSE_PVC=""
 PG_REUSE_IMAGE_TAG=""
 PG_REUSE_UID=1001
 PG_REUSE_PGDIR="data"
+PG_REUSE_SOURCE_POD=""
 
 usage() {
   cat <<'EOF'
@@ -395,10 +396,17 @@ v1_pg_super() {
 
 detect_postgres_reuse() {
   local pod="${SRC_FULLNAME}-postgresql-0"
-  local ver pgdata mount rel uid
+  local ver pgdata mount rel uid modes
   PG_REUSE_PVC="data-${SRC_FULLNAME}-postgresql-0"
+  PG_REUSE_SOURCE_POD=$pod
   kx -n "$NAMESPACE" get pvc "$PG_REUSE_PVC" >/dev/null \
     || die "reuse-volume: PVC $PG_REUSE_PVC not found"
+  modes=$(kx -n "$NAMESPACE" get pvc "$PG_REUSE_PVC" -o jsonpath='{.spec.accessModes[*]}')
+  case " $modes " in
+    *" ReadWriteMany "*) die "reuse-volume: PVC $PG_REUSE_PVC is ReadWriteMany; refusing to attach a live Postgres data dir to a second pod" ;;
+  esac
+  printf '%s' " $modes " | grep -q ' ReadWriteOnce' \
+    || die "reuse-volume: PVC $PG_REUSE_PVC accessModes ($modes) must include ReadWriteOnce"
   kx -n "$NAMESPACE" get pod "$pod" >/dev/null \
     || die "reuse-volume: pod $pod not found (v1 Postgres must be running so we can read version/UID/PGDATA)"
   ver=$(v1_pg_super -d postgres -tAc "SHOW server_version;" | tr -d '[:space:]')
@@ -411,16 +419,17 @@ detect_postgres_reuse() {
   [ -n "$uid" ] || uid=$(kx -n "$NAMESPACE" get pod "$pod" -o jsonpath='{.spec.securityContext.runAsUser}')
   [ -n "$uid" ] || uid=1001
   PG_REUSE_UID=$uid
-  pgdata=$(kx -n "$NAMESPACE" exec "$pod" -- printenv PGDATA | tr -d '[:space:]' || true)
+  pgdata=$(kx -n "$NAMESPACE" exec "$pod" -- printenv PGDATA | tr -d '[:space:]')
+  [ -n "$pgdata" ] || die "reuse-volume: PGDATA is empty on $pod"
   mount=$(kx -n "$NAMESPACE" get pod "$pod" -o jsonpath='{range .spec.containers[0].volumeMounts[*]}{.name}{"\t"}{.mountPath}{"\n"}{end}' \
     | awk -F'\t' '$1=="data"{print $2; exit}')
-  if [ -n "$pgdata" ] && [ -n "$mount" ]; then
-    rel=${pgdata#"$mount"/}
-    if [ "$rel" != "$pgdata" ] && [ -n "$rel" ]; then
-      PG_REUSE_PGDIR=$rel
-    fi
+  [ -n "$mount" ] || die "reuse-volume: could not find the 'data' volume mount on $pod"
+  rel=${pgdata#"$mount"/}
+  if [ "$rel" = "$pgdata" ] || [ -z "$rel" ]; then
+    die "reuse-volume: PGDATA $pgdata is not under the data volume mount $mount"
   fi
-  log "postgres volume reuse: pvc=$PG_REUSE_PVC  image=postgres:$PG_REUSE_IMAGE_TAG  uid=$PG_REUSE_UID  pgDir=$PG_REUSE_PGDIR  (v1 server_version=$ver)"
+  PG_REUSE_PGDIR=$rel
+  log "postgres volume reuse: pvc=$PG_REUSE_PVC  image=postgres:$PG_REUSE_IMAGE_TAG  uid=$PG_REUSE_UID  pgDir=$PG_REUSE_PGDIR  sourcePod=$PG_REUSE_SOURCE_POD  (v1 server_version=$ver)"
 }
 
 retain_postgres_volume() {
@@ -512,6 +521,7 @@ write_values() {
       --postgres-database "$V1_PG_DB"
       --postgres-run-as-user "$PG_REUSE_UID"
       --postgres-pg-dir "$PG_REUSE_PGDIR"
+      --postgres-source-pod "$PG_REUSE_SOURCE_POD"
     )
   fi
   # Feed the JSON converted by yaml_to_json (like the --plan call) so the
@@ -679,13 +689,52 @@ require_sibling_store() {
     || die "resume failed: $kind/$name is missing on $TARGET_RELEASE. helm uninstall $TARGET_RELEASE -n $NAMESPACE and re-run."
 }
 
+require_postgres_reuse_mount() {
+  local sts="${TGT_FULLNAME}-postgresql"
+  local claim vct
+  kx -n "$NAMESPACE" get sts "$sts" >/dev/null \
+    || die "reuse-volume: StatefulSet/$sts not found on $TARGET_RELEASE"
+  vct=$(kx -n "$NAMESPACE" get sts "$sts" -o jsonpath='{.spec.volumeClaimTemplates[*].metadata.name}')
+  claim=$(kx -n "$NAMESPACE" get sts "$sts" -o jsonpath='{range .spec.template.spec.volumes[*]}{.persistentVolumeClaim.claimName}{"\n"}{end}' | awk 'NF' | head -1)
+  if [ -n "$vct" ]; then
+    die "reuse-volume: StatefulSet/$sts still uses volumeClaimTemplates ($vct) instead of PVC $PG_REUSE_PVC. Switching a sibling from logical replication to reuse-volume is a forbidden STS update. helm uninstall $TARGET_RELEASE -n $NAMESPACE and re-run with --postgres-mode reuse-volume."
+  fi
+  if [ "$claim" != "$PG_REUSE_PVC" ]; then
+    die "reuse-volume: StatefulSet/$sts does not mount PVC $PG_REUSE_PVC (got '${claim:-none}'). helm uninstall $TARGET_RELEASE -n $NAMESPACE and re-run."
+  fi
+}
+
+refuse_reuse_comount() {
+  local pod="${TGT_FULLNAME}-postgresql-0"
+  local phase
+  phase=$(kx -n "$NAMESPACE" get pod "$pod" -o jsonpath='{.status.phase}' 2>/dev/null || true)
+  if [ "$phase" = "Running" ]; then
+    die "reuse-volume: $pod is Running while v1 Postgres still holds the volume — possible ReadWriteOnce co-mount on the same node. Aborting."
+  fi
+}
+
+scale_deploy_if_present() {
+  local name=$1 replicas=$2
+  if kx -n "$NAMESPACE" get deploy "$name" >/dev/null 2>&1; then
+    kx -n "$NAMESPACE" scale "deploy/$name" --replicas="$replicas"
+  else
+    log "Deployment/$name not found — skipping scale to $replicas"
+  fi
+}
+
 if ! hx status "$TARGET_RELEASE" -n "$NAMESPACE" >/dev/null 2>&1; then
   confirm "Install v2 release $TARGET_RELEASE alongside $SOURCE_RELEASE (no downtime; ingress stays on v1)?"
   helm_apply "$TARGET_RELEASE" -f "$OUTPUT_VALUES" "${helm_extra[@]+"${helm_extra[@]}"}"
+  if [ "$PG_ON" -eq 1 ] && [ "$PG_MODE" = "reuse-volume" ]; then
+    require_postgres_reuse_mount
+  fi
 else
   RESUME_TARGET=1
   confirm "Resume against existing release $TARGET_RELEASE? Stores must already match the generated overlay."
   [ "$PG_ON" -eq 1 ] && require_sibling_store sts "${TGT_FULLNAME}-postgresql"
+  if [ "$PG_ON" -eq 1 ] && [ "$PG_MODE" = "reuse-volume" ]; then
+    require_postgres_reuse_mount
+  fi
   [ "$S3_ON" -eq 1 ] && require_sibling_store deploy "${TGT_FULLNAME}-s3-all-in-one"
   [ "$CH_ON" -eq 1 ] && require_sibling_store pod "${TGT_FULLNAME}-clickhouse-0-0-0"
   require_sibling_store deploy "$V2_WEB"
@@ -693,7 +742,8 @@ fi
 
 [ "$PG_ON" -eq 1 ] && [ "$PG_MODE" != "reuse-volume" ] && wait_sts "${TGT_FULLNAME}-postgresql"
 if [ "$PG_ON" -eq 1 ] && [ "$PG_MODE" = "reuse-volume" ]; then
-  log "postgres volume reuse: sibling STS ${TGT_FULLNAME}-postgresql will stay Pending until v1 releases PVC $PG_REUSE_PVC"
+  log "postgres volume reuse: sibling STS ${TGT_FULLNAME}-postgresql stays unschedulable until v1 Postgres leaves the node (required anti-affinity on $PG_REUSE_SOURCE_POD)"
+  refuse_reuse_comount
 fi
 [ "$REDIS_ON" -eq 1 ] && {
   if kx -n "$NAMESPACE" get sts "${TGT_FULLNAME}-redis" >/dev/null 2>&1; then
@@ -910,14 +960,18 @@ if [ "$V1_WEB_HAD_REPLICAS" -eq 1 ]; then
 else
   log "v1 web was already at 0 replicas — skipping queue drain"
 fi
-kx -n "$NAMESPACE" scale deploy/"${SRC_FULLNAME}-worker" --replicas=0 >/dev/null 2>&1 || true
+scale_deploy_if_present "${SRC_FULLNAME}-worker" 0
 
 if [ "$PG_ON" -eq 1 ] && [ "$PG_MODE" = "reuse-volume" ]; then
   confirm "Detach Bitnami Postgres from PVC $PG_REUSE_PVC and start sibling Postgres on that volume?"
+  refuse_reuse_comount
   retain_postgres_volume
   log "scaling ${SRC_FULLNAME}-postgresql to 0 (releases the RWO volume)"
   kx -n "$NAMESPACE" scale "sts/${SRC_FULLNAME}-postgresql" --replicas=0
-  kx -n "$NAMESPACE" wait pod "${SRC_FULLNAME}-postgresql-0" --for=delete --timeout=180s || true
+  if kx -n "$NAMESPACE" get pod "${SRC_FULLNAME}-postgresql-0" >/dev/null 2>&1; then
+    kx -n "$NAMESPACE" wait pod "${SRC_FULLNAME}-postgresql-0" --for=delete --timeout=180s \
+      || die "reuse-volume: v1 Postgres pod did not terminate; refusing to attach the volume"
+  fi
   wait_sts "${TGT_FULLNAME}-postgresql"
 elif [ "$PG_ON" -eq 1 ]; then
   log "waiting for Postgres lag_bytes=0"
@@ -945,12 +999,9 @@ if [ "$CH_ON" -eq 1 ]; then
 fi
 
 # --- 8. Bring v2 writers up, then shift traffic -----------------------------
-if [ "$V1_WEB_HAD_REPLICAS" -eq 0 ]; then
-  log "v1 web was at 0 replicas — leaving $V2_WEB scaled down (stores migrated; no traffic shift)"
-else
 log "scaling $V2_WEB / $V2_WORKER up"
 kx -n "$NAMESPACE" scale deploy/"$V2_WEB" --replicas=1
-kx -n "$NAMESPACE" scale deploy/"$V2_WORKER" --replicas=1 >/dev/null 2>&1 || true
+scale_deploy_if_present "$V2_WORKER" 1
 wait_deploy "$V2_WEB"
 
 if [ "$INGRESS_ON" -eq 1 ]; then
@@ -981,7 +1032,6 @@ READY=$(kx -n "$NAMESPACE" run "${TGT_FULLNAME}-ready-check" --rm -i --restart=N
   curl -sf "http://${V2_WEB}.${NAMESPACE}.svc.cluster.local:3000/api/public/ready" || true)
 log "v2 readiness: ${READY:-<empty>}"
 [ -n "$READY" ] || fail_or_force "v2 readiness check failed for Service/$V2_WEB"
-fi
 
 cat <<EOF
 

--- a/examples/upgrade-v1-to-v2/scripts/migrate-values.py
+++ b/examples/upgrade-v1-to-v2/scripts/migrate-values.py
@@ -288,15 +288,17 @@ def apply_postgres_volume_reuse(
     password: str | None,
     run_as_user: int,
     pg_dir: str,
+    source_pod: str | None = None,
 ) -> None:
     """Mount the Bitnami PVC on groundhog2k/postgres instead of creating a new volume.
 
     Bitnami stores PGDATA in a `data/` subdirectory of the volume and runs as UID
     1001. Official postgres (groundhog2k) defaults to `/var/lib/postgresql/data/pg`
     and UID 999 — both must be overridden or the existing files are invisible /
-    unreadable. The sibling overlay keeps replicaCount at the sub-chart default
-    (1); the migration script leaves v1 Postgres running until freeze so the v2
-    pod stays Pending on the RWO volume, then scales v1 to 0.
+    unreadable. ReadWriteOnce is per-node, not per-pod, so a required anti-affinity
+    against the v1 Postgres pod keeps the sibling off that node (and therefore
+    unable to attach) until freeze scales v1 to 0. The existing PVC access mode is
+    left unchanged: ReadWriteOncePod cannot be patched onto a bound claim.
     """
     uid = int(run_as_user)
     # The chart blocks a helm upgrade that still deploys Postgres when the
@@ -349,7 +351,7 @@ def apply_postgres_volume_reuse(
                 (
                     "set -e\n"
                     f'DATA="{data_dir}"\n'
-                    'if [ ! -f "$DATA/PG_VERSION" ]; then echo "bitnami-pgconf: no PG_VERSION in $DATA"; exit 0; fi\n'
+                    'if [ ! -f "$DATA/PG_VERSION" ]; then echo "bitnami-pgconf: no PG_VERSION in $DATA (wrong pgDir? refusing to initdb an empty cluster)"; exit 1; fi\n'
                     'if [ ! -f "$DATA/postgresql.conf" ]; then\n'
                     '  printf "%s\\n" "listen_addresses = \'*\'" "port = 5432" '
                     '"unix_socket_directories = \'/tmp\'" "password_encryption = scram-sha-256" '
@@ -384,6 +386,21 @@ def apply_postgres_volume_reuse(
     pg["customStartupProbe"] = {**probe_exec, "failureThreshold": 30}
     pg["customLivenessProbe"] = {**probe_exec, "failureThreshold": 3}
     pg["customReadinessProbe"] = {**probe_exec, "failureThreshold": 3}
+    if source_pod:
+        pg["affinity"] = {
+            "podAntiAffinity": {
+                "requiredDuringSchedulingIgnoredDuringExecution": [
+                    {
+                        "labelSelector": {
+                            "matchLabels": {
+                                "statefulset.kubernetes.io/pod-name": source_pod,
+                            }
+                        },
+                        "topologyKey": "kubernetes.io/hostname",
+                    }
+                ]
+            }
+        }
 
 
 def migrate_sibling(
@@ -470,6 +487,10 @@ def main() -> int:
     )
     p.add_argument("--postgres-run-as-user", type=int, default=1001, help="UID/GID of the Bitnami data files (default 1001)")
     p.add_argument("--postgres-pg-dir", default="data", help="PGDATA directory on the Bitnami volume (default data)")
+    p.add_argument(
+        "--postgres-source-pod",
+        help="v1 Postgres pod name for required anti-affinity (reuse-volume). Prevents RWO co-mount on the same node",
+    )
     args = p.parse_args()
 
     v1 = load(None if args.input == "-" else args.input)
@@ -495,6 +516,12 @@ def main() -> int:
         if not args.postgres_pvc or not args.postgres_image_tag:
             sys.stderr.write("error: --postgres-pvc and --postgres-image-tag are required for reuse-volume\n")
             return 2
+        if not args.postgres_source_pod:
+            sys.stderr.write(
+                "error: --postgres-source-pod is required for reuse-volume "
+                "(required anti-affinity against the v1 Postgres pod; ReadWriteOnce is per-node)\n"
+            )
+            return 2
         pg_src = v1.get("postgresql") or {}
         auth_src = pg_src.get("auth") if isinstance(pg_src, dict) else {}
         if not isinstance(auth_src, dict):
@@ -513,6 +540,7 @@ def main() -> int:
             "password": password,
             "run_as_user": args.postgres_run_as_user,
             "pg_dir": args.postgres_pg_dir,
+            "source_pod": args.postgres_source_pod,
         }
 
     if mode in ("sibling", "cutover"):

--- a/examples/upgrade-v1-to-v2/scripts/migrate-values.py
+++ b/examples/upgrade-v1-to-v2/scripts/migrate-values.py
@@ -16,11 +16,19 @@ Modes:
             Service names stay on that release.
 
 Reads YAML (or JSON) on stdin / --input and writes v2 values YAML to stdout.
+
+Postgres data movement (sibling/cutover only, when postgresql.deploy is true):
+
+  logical        Default. Empty sibling Postgres; copy with logical replication.
+  reuse-volume   Point the sibling at the Bitnami PVC (data-<src>-postgresql-0)
+                 after v1 Postgres is scaled to 0. Same major version, auth, and
+                 on-disk layout (settings.pgDir=data). No online copy.
 """
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from typing import Any
 
@@ -257,7 +265,134 @@ def apply_auth_secrets(v2: dict[str, Any], fullname: str) -> dict[str, Any]:
     return v2
 
 
-def migrate_sibling(v1: dict[str, Any], target_fullname: str, *, ingress: bool) -> dict[str, Any]:
+def scale_app_to_zero(v2: dict[str, Any]) -> None:
+    """Keep sibling web/worker off until the reused Postgres volume is attached."""
+    lf = v2.setdefault("langfuse", {})
+    if not isinstance(lf, dict):
+        return
+    lf["replicas"] = 0
+    for comp in ("web", "worker"):
+        block = lf.get(comp)
+        block = dict(block) if isinstance(block, dict) else {}
+        block["replicas"] = 0
+        lf[comp] = block
+
+
+def apply_postgres_volume_reuse(
+    v2: dict[str, Any],
+    *,
+    pvc: str,
+    image_tag: str,
+    username: str,
+    database: str,
+    password: str | None,
+    run_as_user: int,
+    pg_dir: str,
+) -> None:
+    """Mount the Bitnami PVC on groundhog2k/postgres instead of creating a new volume.
+
+    Bitnami stores PGDATA in a `data/` subdirectory of the volume and runs as UID
+    1001. Official postgres (groundhog2k) defaults to `/var/lib/postgresql/data/pg`
+    and UID 999 — both must be overridden or the existing files are invisible /
+    unreadable. The sibling overlay keeps replicaCount at the sub-chart default
+    (1); the migration script leaves v1 Postgres running until freeze so the v2
+    pod stays Pending on the RWO volume, then scales v1 to 0.
+    """
+    uid = int(run_as_user)
+    # The chart blocks a helm upgrade that still deploys Postgres when the
+    # Bitnami PVC data-<release>-postgresql-0 is present (v2 would otherwise
+    # create empty postgres-data-<release>-postgresql-0). reuse-volume keeps
+    # that PVC on purpose, so the guard must be lifted.
+    lf = v2.setdefault("langfuse", {})
+    if isinstance(lf, dict):
+        lf["allowV1Upgrade"] = True
+    pg = v2.setdefault("postgresql", {})
+    pg["deploy"] = True
+    auth = pg.setdefault("auth", {})
+    auth["username"] = username
+    auth["database"] = database
+    if password:
+        auth["password"] = password
+    settings = pg.setdefault("settings", {})
+    settings["pgDir"] = pg_dir
+    # Bitnami 1.5.x ships Debian 12 (glibc 2.36). Current docker.io/postgres:<major>
+    # is Debian 13 and prints a collation version mismatch; pin bookworm to stay
+    # on glibc 2.36. Bare majors from SHOW server_version get this suffix.
+    tag = str(image_tag)
+    if tag.isdigit():
+        tag = f"{tag}-bookworm"
+    image = pg.setdefault("image", {})
+    image["tag"] = tag
+    storage = pg.setdefault("storage", {})
+    storage["persistentVolumeClaimName"] = pvc
+    pg["podSecurityContext"] = {"fsGroup": uid}
+    pg["securityContext"] = {
+        "runAsUser": uid,
+        "runAsGroup": uid,
+        "runAsNonRoot": True,
+    }
+    data_dir = f"/var/lib/postgresql/data/{pg_dir}".replace("//", "/")
+    pg["extraInitContainers"] = [
+        {
+            "name": "bitnami-pgconf",
+            "image": f"docker.io/postgres:{tag}",
+            "imagePullPolicy": "IfNotPresent",
+            "securityContext": {
+                "runAsUser": uid,
+                "runAsGroup": uid,
+                "runAsNonRoot": True,
+                "allowPrivilegeEscalation": False,
+            },
+            "command": [
+                "sh",
+                "-c",
+                (
+                    "set -e\n"
+                    f'DATA="{data_dir}"\n'
+                    'if [ ! -f "$DATA/PG_VERSION" ]; then echo "bitnami-pgconf: no PG_VERSION in $DATA"; exit 0; fi\n'
+                    'if [ ! -f "$DATA/postgresql.conf" ]; then\n'
+                    '  printf "%s\\n" "listen_addresses = \'*\'" "port = 5432" '
+                    '"unix_socket_directories = \'/tmp\'" "password_encryption = scram-sha-256" '
+                    '> "$DATA/postgresql.conf"\n'
+                    '  echo "bitnami-pgconf: wrote $DATA/postgresql.conf"\n'
+                    "fi\n"
+                    'if [ ! -f "$DATA/pg_hba.conf" ]; then\n'
+                    '  printf "%s\\n" "local   all  all                trust" '
+                    '"host    all  all  127.0.0.1/32  trust" '
+                    '"host    all  all  ::1/128       trust" '
+                    '"host    all  all  0.0.0.0/0     scram-sha-256" '
+                    '"host    all  all  ::/0          scram-sha-256" '
+                    '> "$DATA/pg_hba.conf"\n'
+                    '  echo "bitnami-pgconf: wrote $DATA/pg_hba.conf"\n'
+                    "fi\n"
+                ),
+            ],
+            "volumeMounts": [
+                {"name": "postgres-data", "mountPath": "/var/lib/postgresql/data"},
+            ],
+        }
+    ]
+    # Official image has no passwd entry for Bitnami UID 1001, so the default
+    # `pg_isready -h localhost` returns "no attempt". Probe as the postgres role.
+    probe_exec = {
+        "exec": {"command": ["pg_isready", "-h", "127.0.0.1", "-U", "postgres"]},
+        "initialDelaySeconds": 10,
+        "timeoutSeconds": 5,
+        "periodSeconds": 10,
+        "successThreshold": 1,
+    }
+    pg["customStartupProbe"] = {**probe_exec, "failureThreshold": 30}
+    pg["customLivenessProbe"] = {**probe_exec, "failureThreshold": 3}
+    pg["customReadinessProbe"] = {**probe_exec, "failureThreshold": 3}
+
+
+def migrate_sibling(
+    v1: dict[str, Any],
+    target_fullname: str,
+    *,
+    ingress: bool,
+    postgres_reuse: dict[str, Any] | None = None,
+) -> dict[str, Any]:
     lf = copy_langfuse(v1)
     lf.setdefault("ingress", {})
     if isinstance(lf["ingress"], dict):
@@ -265,7 +400,12 @@ def migrate_sibling(v1: dict[str, Any], target_fullname: str, *, ingress: bool) 
         lf["ingress"]["enabled"] = bool(ingress and ingress_enabled(v1))
     v2: dict[str, Any] = {"langfuse": lf}
     v2.update(store_blocks(v1))
-    return apply_auth_secrets(v2, target_fullname)
+    apply_auth_secrets(v2, target_fullname)
+    if postgres_reuse:
+        apply_postgres_volume_reuse(v2, **postgres_reuse)
+        if not ingress:
+            scale_app_to_zero(v2)
+    return v2
 
 
 def migrate_inplace(v1: dict[str, Any]) -> dict[str, Any]:
@@ -279,13 +419,15 @@ def migrate_inplace(v1: dict[str, Any]) -> dict[str, Any]:
     return v2
 
 
-def plan(v1: dict[str, Any]) -> dict[str, bool]:
+def plan(v1: dict[str, Any], postgres_mode: str = "logical") -> dict[str, Any]:
+    pg = deploy_enabled(v1, "postgresql")
     return {
-        "postgresql": deploy_enabled(v1, "postgresql"),
+        "postgresql": pg,
         "clickhouse": deploy_enabled(v1, "clickhouse"),
         "redis": deploy_enabled(v1, "redis"),
         "s3": deploy_enabled(v1, "s3"),
         "ingress": ingress_enabled(v1),
+        "postgresMode": postgres_mode if pg else "skip",
     }
 
 
@@ -312,11 +454,27 @@ def main() -> int:
         dest="image_tag",
         help="Pin langfuse.image.tag so the sibling / in-place upgrade matches v1",
     )
+    p.add_argument(
+        "--postgres-mode",
+        choices=("logical", "reuse-volume"),
+        default="logical",
+        help="logical (default): replicate into a new volume. reuse-volume: mount the Bitnami PVC on the sibling",
+    )
+    p.add_argument("--postgres-pvc", help="Bitnami PVC name (required for reuse-volume)")
+    p.add_argument("--postgres-image-tag", help="Postgres major/image tag matching v1 (required for reuse-volume)")
+    p.add_argument("--postgres-username", help="Override postgresql.auth.username for reuse-volume")
+    p.add_argument("--postgres-database", help="Override postgresql.auth.database for reuse-volume")
+    p.add_argument(
+        "--postgres-password",
+        help="v1 superuser password (or set POSTGRES_REUSE_PASSWORD). Written into the generated overlay",
+    )
+    p.add_argument("--postgres-run-as-user", type=int, default=1001, help="UID/GID of the Bitnami data files (default 1001)")
+    p.add_argument("--postgres-pg-dir", default="data", help="PGDATA directory on the Bitnami volume (default data)")
     args = p.parse_args()
 
     v1 = load(None if args.input == "-" else args.input)
     if args.plan:
-        json.dump(plan(v1), sys.stdout)
+        json.dump(plan(v1, args.postgres_mode), sys.stdout)
         sys.stdout.write("\n")
         return 0
 
@@ -326,11 +484,47 @@ def main() -> int:
     elif mode == "stores":
         mode = "sibling"
 
+    postgres_reuse = None
+    if args.postgres_mode == "reuse-volume":
+        if mode == "inplace":
+            sys.stderr.write("error: --postgres-mode reuse-volume is only valid for sibling/cutover (bundled Postgres)\n")
+            return 2
+        if not deploy_enabled(v1, "postgresql"):
+            sys.stderr.write("error: --postgres-mode reuse-volume requires postgresql.deploy=true\n")
+            return 2
+        if not args.postgres_pvc or not args.postgres_image_tag:
+            sys.stderr.write("error: --postgres-pvc and --postgres-image-tag are required for reuse-volume\n")
+            return 2
+        pg_src = v1.get("postgresql") or {}
+        auth_src = pg_src.get("auth") if isinstance(pg_src, dict) else {}
+        if not isinstance(auth_src, dict):
+            auth_src = {}
+        password = (
+            os.environ.get("POSTGRES_REUSE_PASSWORD")
+            or args.postgres_password
+            or auth_src.get("password")
+            or None
+        )
+        postgres_reuse = {
+            "pvc": args.postgres_pvc,
+            "image_tag": args.postgres_image_tag,
+            "username": args.postgres_username or auth_src.get("username") or "postgres",
+            "database": args.postgres_database or auth_src.get("database") or "postgres_langfuse",
+            "password": password,
+            "run_as_user": args.postgres_run_as_user,
+            "pg_dir": args.postgres_pg_dir,
+        }
+
     if mode in ("sibling", "cutover"):
         if not args.target_fullname:
             sys.stderr.write("error: --target-fullname is required for sibling/cutover\n")
             return 2
-        data = migrate_sibling(v1, args.target_fullname, ingress=(mode == "cutover"))
+        data = migrate_sibling(
+            v1,
+            args.target_fullname,
+            ingress=(mode == "cutover"),
+            postgres_reuse=postgres_reuse,
+        )
         warn_dropped(v1)
     else:
         data = migrate_inplace(v1)


### PR DESCRIPTION
Adds an opt-in `--postgres-mode reuse-volume` path for the v1 to v2 migration: instead of logical replication onto a new disk, the sibling OSS Postgres chart re-uses the Bitnami PVC after it scaled to 0.

The generated overlay pins the source major version (<major>-bookworm), Bitnami UID/PGDATA layout, and credentials, writes the missing postgresql.conf/pg_hba.conf (For Bitnami they live in the image, not on the volume), and set langfuse.allowV1Upgrade so the chart guard does not treat that leftover PVC name as v1 indicator.

Due to the naming, upgrade and standard restriction the default remains `logical` replication.