### PR TITLE
feat: expose priorityClassName on web, worker and ClickHouse pods

### DIFF
--- a/charts/langfuse/README.md
+++ b/charts/langfuse/README.md
@@ -38,6 +38,7 @@ Open source LLM engineering platform - LLM observability, metrics, evaluations, 
 | clickhouse.cluster.image.repository | string | `"clickhouse/clickhouse-server"` | ClickHouse server image repository. |
 | clickhouse.cluster.image.tag | string | `"26.4"` | ClickHouse server image tag. Keep aligned with the version recommended for Langfuse v4. |
 | clickhouse.cluster.nodeSelector | object | `{}` | Node selector for ClickHouse pods. |
+| clickhouse.cluster.priorityClassName | string | `""` | PriorityClass for ClickHouse pods. |
 | clickhouse.cluster.profileSettings | object | `{}` | Extra ClickHouse user profile settings mounted into users.xml. |
 | clickhouse.cluster.replicas | int | `1` | Number of ClickHouse replicas. 1 is a valid single-pod cluster; 2+ requires Keeper enabled. |
 | clickhouse.cluster.resources | object | `{"limits":{"memory":"4Gi"},"requests":{"cpu":"1","memory":"2Gi"}}` | CPU/memory for ClickHouse pods. Non-empty defaults avoid the operator's ~1Gi fallback that OOMs under load. |
@@ -56,6 +57,7 @@ Open source LLM engineering platform - LLM observability, metrics, evaluations, 
 | clickhouse.keeper.image.repository | string | `"clickhouse/clickhouse-keeper"` | ClickHouse Keeper image repository. |
 | clickhouse.keeper.image.tag | string | `"26.4"` | ClickHouse Keeper image tag. Keep aligned with the ClickHouse server tag. |
 | clickhouse.keeper.nodeSelector | object | `{}` | Node selector for Keeper pods. |
+| clickhouse.keeper.priorityClassName | string | `""` | PriorityClass for Keeper pods. |
 | clickhouse.keeper.replicas | int | `3` | Keeper replica count (must be odd: 1, 3, or 5). Use 3 for production HA. |
 | clickhouse.keeper.resources | object | `{"limits":{"memory":"1Gi"},"requests":{"cpu":"250m","memory":"256Mi"}}` | CPU/memory requests and limits for Keeper pods. |
 | clickhouse.keeper.storage.accessModes[0] | string | `"ReadWriteOnce"` |  |
@@ -106,6 +108,7 @@ Open source LLM engineering platform - LLM observability, metrics, evaluations, 
 | langfuse.pod.labels | object | `{}` | Labels for all langfuse pods |
 | langfuse.pod.topologySpreadConstraints | list | `[]` | Topology spread constraints for all langfuse pods |
 | langfuse.podSecurityContext | object | `{}` | Pod security context for all langfuse deployments |
+| langfuse.priorityClassName | string | `""` | PriorityClass for all langfuse deployments |
 | langfuse.replicas | int | `1` | Number of replicas to use for all langfuse deployments. Can be overridden by the individual deployments |
 | langfuse.resources | object | `{}` | Resources for all langfuse deployments. Can be overridden by the individual deployments |
 | langfuse.revisionHistoryLimit | int | `10` | Number of old ReplicaSets to retain to allow rollback. Can be overridden by the individual deployments |
@@ -155,6 +158,7 @@ Open source LLM engineering platform - LLM observability, metrics, evaluations, 
 | langfuse.web.pod.extraContainers | list | `[]` | Allows additional containers to be added to all langfuse web pods |
 | langfuse.web.pod.labels | object | `{}` | Labels for the web pods |
 | langfuse.web.pod.nodeSelector | string | `nil` | Node selector for the web pods. Overrides the global nodeSelector |
+| langfuse.web.pod.priorityClassName | string | `nil` | PriorityClass for the web pods. Overrides the global priorityClassName |
 | langfuse.web.pod.tolerations | string | `nil` | Tolerations for the web pods. Overrides the global tolerations |
 | langfuse.web.pod.topologySpreadConstraints | string | `nil` | Topology spread constraints for the web pods. Overrides the global topologySpreadConstraints |
 | langfuse.web.readinessProbe.failureThreshold | int | `3` | Failure threshold for readinessProbe. |
@@ -213,6 +217,7 @@ Open source LLM engineering platform - LLM observability, metrics, evaluations, 
 | langfuse.worker.pod.extraContainers | list | `[]` | Allows additional containers to be added to all langfuse worker pods |
 | langfuse.worker.pod.labels | object | `{}` | Labels for the worker pods |
 | langfuse.worker.pod.nodeSelector | string | `nil` | Node selector for the worker pods. Overrides the global nodeSelector |
+| langfuse.worker.pod.priorityClassName | string | `nil` | PriorityClass for the worker pods. Overrides the global priorityClassName |
 | langfuse.worker.pod.tolerations | string | `nil` | Tolerations for the worker pods. Overrides the global tolerations |
 | langfuse.worker.pod.topologySpreadConstraints | string | `nil` | Topology spread constraints for the worker pods. Overrides the global topologySpreadConstraints |
 | langfuse.worker.replicas | string | `nil` | Number of replicas to use if HPA is not enabled. Defaults to the global replicas |

--- a/charts/langfuse/templates/clickhouse/cluster.yaml
+++ b/charts/langfuse/templates/clickhouse/cluster.yaml
@@ -29,7 +29,7 @@ spec:
     resources:
       {{- toYaml . | nindent 6 }}
     {{- end }}
-  {{- if or .Values.clickhouse.cluster.nodeSelector .Values.clickhouse.cluster.tolerations .Values.clickhouse.cluster.affinity }}
+  {{- if or .Values.clickhouse.cluster.nodeSelector .Values.clickhouse.cluster.tolerations .Values.clickhouse.cluster.affinity .Values.clickhouse.cluster.priorityClassName }}
   podTemplate:
     {{- with .Values.clickhouse.cluster.nodeSelector }}
     nodeSelector:
@@ -42,6 +42,9 @@ spec:
     {{- with .Values.clickhouse.cluster.affinity }}
     affinity:
       {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.clickhouse.cluster.priorityClassName }}
+    priorityClassName: {{ . | quote }}
     {{- end }}
   {{- end }}
   settings:

--- a/charts/langfuse/templates/clickhouse/keeper.yaml
+++ b/charts/langfuse/templates/clickhouse/keeper.yaml
@@ -25,7 +25,7 @@ spec:
     resources:
       {{- toYaml . | nindent 6 }}
     {{- end }}
-  {{- if or .Values.clickhouse.keeper.nodeSelector .Values.clickhouse.keeper.tolerations .Values.clickhouse.keeper.affinity }}
+  {{- if or .Values.clickhouse.keeper.nodeSelector .Values.clickhouse.keeper.tolerations .Values.clickhouse.keeper.affinity .Values.clickhouse.keeper.priorityClassName }}
   podTemplate:
     {{- with .Values.clickhouse.keeper.nodeSelector }}
     nodeSelector:
@@ -38,6 +38,9 @@ spec:
     {{- with .Values.clickhouse.keeper.affinity }}
     affinity:
       {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.clickhouse.keeper.priorityClassName }}
+    priorityClassName: {{ . | quote }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/langfuse/templates/web/deployment.yaml
+++ b/charts/langfuse/templates/web/deployment.yaml
@@ -139,6 +139,9 @@ spec:
       topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with (coalesce .Values.langfuse.web.pod.priorityClassName .Values.langfuse.priorityClassName) }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}
       {{- with .Values.langfuse.dnsConfig }}
       dnsConfig:
         {{- toYaml . | nindent 8 }}

--- a/charts/langfuse/templates/worker/deployment.yaml
+++ b/charts/langfuse/templates/worker/deployment.yaml
@@ -128,6 +128,9 @@ spec:
       topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with (coalesce .Values.langfuse.worker.pod.priorityClassName .Values.langfuse.priorityClassName) }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}
       {{- with .Values.langfuse.dnsConfig }}
       dnsConfig:
         {{- toYaml . | nindent 8 }}

--- a/charts/langfuse/tests/priority-class_test.yaml
+++ b/charts/langfuse/tests/priority-class_test.yaml
@@ -1,0 +1,71 @@
+suite: test priorityClassName
+templates:
+  - web/deployment.yaml
+  - worker/deployment.yaml
+  - clickhouse/cluster.yaml
+  - clickhouse/keeper.yaml
+tests:
+  - it: should not set priorityClassName by default
+    values:
+      - ../values.lint.yaml
+    asserts:
+      - notExists:
+          path: spec.template.spec.priorityClassName
+        template: web/deployment.yaml
+      - notExists:
+          path: spec.template.spec.priorityClassName
+        template: worker/deployment.yaml
+      - notExists:
+          path: spec.podTemplate
+        template: clickhouse/cluster.yaml
+      - notExists:
+          path: spec.podTemplate
+        template: clickhouse/keeper.yaml
+
+  - it: should apply the global priorityClassName to the web and worker pods
+    values:
+      - ../values.lint.yaml
+    set:
+      langfuse.priorityClassName: app-critical
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: app-critical
+        template: web/deployment.yaml
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: app-critical
+        template: worker/deployment.yaml
+
+  - it: should let the per-deployment priorityClassName override the global one
+    values:
+      - ../values.lint.yaml
+    set:
+      langfuse.priorityClassName: app-critical
+      langfuse.web.pod.priorityClassName: app-web-critical
+      langfuse.worker.pod.priorityClassName: app-non-critical
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: app-web-critical
+        template: web/deployment.yaml
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: app-non-critical
+        template: worker/deployment.yaml
+
+  - it: should set priorityClassName on the ClickHouseCluster and KeeperCluster pod templates
+    values:
+      - ../values.lint.yaml
+    set:
+      clickhouse.cluster.priorityClassName: clickhouse-critical
+      clickhouse.keeper.priorityClassName: keeper-critical
+    asserts:
+      - equal:
+          path: spec.podTemplate.priorityClassName
+          value: clickhouse-critical
+        template: clickhouse/cluster.yaml
+      - equal:
+          path: spec.podTemplate.priorityClassName
+          value: keeper-critical
+        template: clickhouse/keeper.yaml

--- a/charts/langfuse/values.yaml
+++ b/charts/langfuse/values.yaml
@@ -115,6 +115,8 @@ langfuse:
   tolerations: []
   # -- Affinity for all langfuse deployments
   affinity: {}
+  # -- PriorityClass for all langfuse deployments
+  priorityClassName: ""
   # -- DNS configuration for all langfuse deployments
   dnsConfig: {}
   pod:
@@ -190,6 +192,8 @@ langfuse:
       affinity: null
       # -- Topology spread constraints for the web pods. Overrides the global topologySpreadConstraints
       topologySpreadConstraints: null
+      # -- PriorityClass for the web pods. Overrides the global priorityClassName
+      priorityClassName: null
       # -- Allows additional containers to be added to all langfuse web pods
       extraContainers: []
       # -- List of additional environment variables to be added to all langfuse web pods. See [documentation](https://langfuse.com/docs/deployment/self-host#configuring-environment-variables) for details.
@@ -340,6 +344,8 @@ langfuse:
       affinity: null
       # -- Topology spread constraints for the worker pods. Overrides the global topologySpreadConstraints
       topologySpreadConstraints: null
+      # -- PriorityClass for the worker pods. Overrides the global priorityClassName
+      priorityClassName: null
       # -- Allows additional containers to be added to all langfuse worker pods
       extraContainers: []
       # -- List of additional environment variables to be added to all langfuse worker pods. See [documentation](https://langfuse.com/docs/deployment/self-host#configuring-environment-variables) for details.
@@ -754,6 +760,8 @@ clickhouse:
     tolerations: []
     # -- Affinity rules for ClickHouse pods.
     affinity: {}
+    # -- PriorityClass for ClickHouse pods.
+    priorityClassName: ""
     # -- Extra ClickHouse server settings applied under the `<clickhouse>` config section.
     settings: {}
     # -- Extra ClickHouse user profile settings mounted into users.xml.
@@ -789,6 +797,8 @@ clickhouse:
     tolerations: []
     # -- Affinity rules for Keeper pods.
     affinity: {}
+    # -- PriorityClass for Keeper pods.
+    priorityClassName: ""
 
 # S3 / Object Storage Configuration
 # Deploys SeaweedFS in allInOne mode via the seaweedfs/seaweedfs sub-chart (image `chrislusf/seaweedfs`).


### PR DESCRIPTION
Closes #406.

## What

The chart exposes every other pod-level scheduling field on the web and worker deployments — `nodeSelector`, `tolerations`, `affinity`, `topologySpreadConstraints` — but not `priorityClassName`, so the pods sit at priority 0 on clusters that order eviction by PriorityClass, even though web fronts the ingestion API and worker drains the event queue.

The same gap exists on the `ClickHouseCluster` / `KeeperCluster` CRs the chart renders: their `podTemplate` already carries `nodeSelector` / `tolerations` / `affinity`, and the CRD accepts `priorityClassName` next to them ([`PodTemplateSpec`](https://github.com/ClickHouse/clickhouse-operator/blob/main/api/v1alpha1/common.go)).

```yaml
langfuse:
  priorityClassName: ""       # applies to web and worker
  web:
    pod:
      priorityClassName: null # optional override
  worker:
    pod:
      priorityClassName: null

clickhouse:
  cluster:
    priorityClassName: ""
  keeper:
    priorityClassName: ""
```

The layering matches the existing fields exactly: `coalesce <deployment>.pod.priorityClassName langfuse.priorityClassName` for the deployments, a plain `with` for the two CRs (whose `podTemplate` block is now also emitted when only `priorityClassName` is set).

The three bundled stores need no chart change — `postgresql.priorityClassName` (groundhog2k/postgres), `redis.priorityClassName` (valkey) and the per-component `s3.*.priorityClassName` (seaweedfs) already reach their sub-charts through the existing value passthrough.


No `Chart.yaml` version bump, leaving the release to the maintainers.