### PR TITLE
fix: keep migration secrets out of process arguments

### DIFF
--- a/examples/upgrade-v1-to-v2/README.md
+++ b/examples/upgrade-v1-to-v2/README.md
@@ -163,22 +163,9 @@ Run Postgres, object storage, and ClickHouse syncs in parallel.
 
 ##### 2a. PostgreSQL — logical replication
 
-```bash
-kubectl -n langfuse exec langfuse-postgresql-0 -- \
-  psql -U postgres -d postgres_langfuse -c "CREATE PUBLICATION lf_pub FOR ALL TABLES;"
-
-SU_PW=$(kubectl -n langfuse get secret langfuse-v2-postgresql-auth -o jsonpath='{.data.POSTGRES_PASSWORD}' | base64 -d)
-kubectl -n langfuse exec langfuse-v2-postgresql-0 -- env PGPASSWORD="$SU_PW" psql -U postgres -d langfuse -tAc \
-  "SELECT 'TRUNCATE TABLE '||string_agg(format('%I.%I',schemaname,tablename),', ')||' CASCADE;' \
-   FROM pg_tables WHERE schemaname='public';" | \
-  kubectl -n langfuse exec -i langfuse-v2-postgresql-0 -- env PGPASSWORD="$SU_PW" psql -U postgres -d langfuse
-
-V1_PW=$(kubectl -n langfuse get secret langfuse-postgresql -o jsonpath='{.data.postgres-password}' | base64 -d)
-kubectl -n langfuse exec langfuse-v2-postgresql-0 -- env PGPASSWORD="$SU_PW" psql -U postgres -d langfuse -c \
-  "CREATE SUBSCRIPTION lf_sub \
-   CONNECTION 'host=langfuse-postgresql port=5432 dbname=postgres_langfuse user=postgres password=${V1_PW}' \
-   PUBLICATION lf_pub;"
-```
+Use `scripts/migrate-v1-to-v2.sh`. It reads both PostgreSQL passwords from the
+cluster Secrets and carries them to `psql` over stdin. Do not place passwords in
+`kubectl exec` arguments or inline SQL passed with `psql -c`.
 
 Watch catch-up (`lag_bytes=0`):
 
@@ -189,17 +176,9 @@ kubectl -n langfuse exec langfuse-postgresql-0 -- psql -U postgres -d postgres_l
 
 ##### 2b. Object storage — MinIO → SeaweedFS
 
-```bash
-V1_KEY=$(kubectl -n langfuse get secret langfuse-s3 -o jsonpath='{.data.root-user}' | base64 -d)
-V1_SECRET=$(kubectl -n langfuse get secret langfuse-s3 -o jsonpath='{.data.root-password}' | base64 -d)
-V2_KEY=$(kubectl -n langfuse get secret langfuse-v2-s3-auth -o jsonpath='{.data.accessKey}' | base64 -d)
-V2_SECRET=$(kubectl -n langfuse get secret langfuse-v2-s3-auth -o jsonpath='{.data.secretKey}' | base64 -d)
-
-mc alias set v1 http://langfuse-s3.langfuse.svc.cluster.local:9000 "$V1_KEY" "$V1_SECRET"
-mc alias set v2 http://langfuse-v2-s3-all-in-one.langfuse.svc.cluster.local:8333 "$V2_KEY" "$V2_SECRET"
-mc mb --ignore-existing v2/langfuse
-mc mirror --overwrite --watch v1/langfuse v2/langfuse
-```
+Use `scripts/migrate-v1-to-v2.sh`. It imports both `mc` aliases from JSON over
+stdin before starting the mirror. Do not pass access keys or secret keys to
+`mc alias set` as command arguments.
 
 ##### 2c. ClickHouse — `remote()` watermark loop
 

--- a/examples/upgrade-v1-to-v2/README.md
+++ b/examples/upgrade-v1-to-v2/README.md
@@ -163,9 +163,22 @@ Run Postgres, object storage, and ClickHouse syncs in parallel.
 
 ##### 2a. PostgreSQL — logical replication
 
-Use `scripts/migrate-v1-to-v2.sh`. It reads both PostgreSQL passwords from the
-cluster Secrets and carries them to `psql` over stdin. Do not place passwords in
-`kubectl exec` arguments or inline SQL passed with `psql -c`.
+```bash
+kubectl -n langfuse exec langfuse-postgresql-0 -- \
+  psql -U postgres -d postgres_langfuse -c "CREATE PUBLICATION lf_pub FOR ALL TABLES;"
+
+SU_PW=$(kubectl -n langfuse get secret langfuse-v2-postgresql-auth -o jsonpath='{.data.POSTGRES_PASSWORD}' | base64 -d)
+kubectl -n langfuse exec langfuse-v2-postgresql-0 -- env PGPASSWORD="$SU_PW" psql -U postgres -d langfuse -tAc \
+  "SELECT 'TRUNCATE TABLE '||string_agg(format('%I.%I',schemaname,tablename),', ')||' CASCADE;' \
+   FROM pg_tables WHERE schemaname='public';" | \
+  kubectl -n langfuse exec -i langfuse-v2-postgresql-0 -- env PGPASSWORD="$SU_PW" psql -U postgres -d langfuse
+
+V1_PW=$(kubectl -n langfuse get secret langfuse-postgresql -o jsonpath='{.data.postgres-password}' | base64 -d)
+kubectl -n langfuse exec langfuse-v2-postgresql-0 -- env PGPASSWORD="$SU_PW" psql -U postgres -d langfuse -c \
+  "CREATE SUBSCRIPTION lf_sub \
+   CONNECTION 'host=langfuse-postgresql port=5432 dbname=postgres_langfuse user=postgres password=${V1_PW}' \
+   PUBLICATION lf_pub;"
+```
 
 Watch catch-up (`lag_bytes=0`):
 
@@ -176,9 +189,17 @@ kubectl -n langfuse exec langfuse-postgresql-0 -- psql -U postgres -d postgres_l
 
 ##### 2b. Object storage — MinIO → SeaweedFS
 
-Use `scripts/migrate-v1-to-v2.sh`. It imports both `mc` aliases from JSON over
-stdin before starting the mirror. Do not pass access keys or secret keys to
-`mc alias set` as command arguments.
+```bash
+V1_KEY=$(kubectl -n langfuse get secret langfuse-s3 -o jsonpath='{.data.root-user}' | base64 -d)
+V1_SECRET=$(kubectl -n langfuse get secret langfuse-s3 -o jsonpath='{.data.root-password}' | base64 -d)
+V2_KEY=$(kubectl -n langfuse get secret langfuse-v2-s3-auth -o jsonpath='{.data.accessKey}' | base64 -d)
+V2_SECRET=$(kubectl -n langfuse get secret langfuse-v2-s3-auth -o jsonpath='{.data.secretKey}' | base64 -d)
+
+mc alias set v1 http://langfuse-s3.langfuse.svc.cluster.local:9000 "$V1_KEY" "$V1_SECRET"
+mc alias set v2 http://langfuse-v2-s3-all-in-one.langfuse.svc.cluster.local:8333 "$V2_KEY" "$V2_SECRET"
+mc mb --ignore-existing v2/langfuse
+mc mirror --overwrite --watch v1/langfuse v2/langfuse
+```
 
 ##### 2c. ClickHouse — `remote()` watermark loop
 

--- a/examples/upgrade-v1-to-v2/scripts/ch-online-sync.sh
+++ b/examples/upgrade-v1-to-v2/scripts/ch-online-sync.sh
@@ -70,8 +70,22 @@ mkdir -p "$STATE_DIR"
 TPW=$(kx -n "$TARGET_NS" get secret "$TARGET_SECRET" -o jsonpath="{.data.$TARGET_SECRET_KEY}" | base64 -d)
 SPW=$(kx -n "$SOURCE_NS" get secret "$SOURCE_SECRET" -o jsonpath="{.data.$SOURCE_SECRET_KEY}" | base64 -d)
 
-# Run a query on the target ClickHouse (stdin-safe).
-chq() { kx -n "$TARGET_NS" exec -i "$TARGET_POD" -- clickhouse-client --password "$TPW" -q "$1"; }
+# Run a query on the target ClickHouse. The target password and query, which can
+# contain the source password in remote(), are both carried over stdin.
+chq() {
+  local password_length
+  password_length=$(LC_ALL=C printf '%s' "$TPW" | wc -c | tr -d '[:space:]')
+  {
+    printf '%s' "$TPW"
+    printf '%s\n' "$1"
+  } | kx -n "$TARGET_NS" exec -i "$TARGET_POD" -- sh -c '
+    password_length=$1
+    CLICKHOUSE_PASSWORD=$({ dd bs=1 count="$password_length" 2>/dev/null; printf .; })
+    CLICKHOUSE_PASSWORD=${CLICKHOUSE_PASSWORD%?}
+    export CLICKHOUSE_PASSWORD
+    exec clickhouse-client --multiquery
+  ' sh "$password_length"
+}
 
 remote_expr() { echo "remote('$SOURCE_HOST','$SOURCE_DB.$1','$SOURCE_USER','$SPW')"; }
 

--- a/examples/upgrade-v1-to-v2/scripts/migrate-v1-to-v2.sh
+++ b/examples/upgrade-v1-to-v2/scripts/migrate-v1-to-v2.sh
@@ -79,6 +79,42 @@ need_cmd() {
 kx() { "$KUBECTL" ${KCTX:+--context "$KCTX"} "$@"; }
 hx() { "$HELM" ${KCTX:+--kube-context "$KCTX"} "$@"; }
 
+kx_exec_with_secret_env() {
+  local forward_stdin=0
+  if [ "${1:-}" = "--forward-stdin" ]; then
+    forward_stdin=1
+    shift
+  fi
+  local namespace=$1 pod=$2 env_name=$3 secret=$4
+  shift 4
+  local secret_length
+  secret_length=$(LC_ALL=C printf '%s' "$secret" | wc -c | tr -d '[:space:]')
+  if [ "$forward_stdin" -eq 1 ]; then
+    {
+      printf '%s' "$secret"
+      cat
+    } | kx -n "$namespace" exec -i "$pod" -- sh -c '
+      secret_length=$1
+      env_name=$2
+      shift 2
+      secret=$({ dd bs=1 count="$secret_length" 2>/dev/null; printf .; })
+      secret=${secret%?}
+      export "$env_name=$secret"
+      exec "$@"
+    ' sh "$secret_length" "$env_name" "$@"
+  else
+    printf '%s' "$secret" | kx -n "$namespace" exec -i "$pod" -- sh -c '
+      secret_length=$1
+      env_name=$2
+      shift 2
+      secret=$({ dd bs=1 count="$secret_length" 2>/dev/null; printf .; })
+      secret=${secret%?}
+      export "$env_name=$secret"
+      exec "$@"
+    ' sh "$secret_length" "$env_name" "$@"
+  fi
+}
+
 confirm() {
   local msg=$1
   if [ "$YES" -eq 1 ]; then
@@ -376,7 +412,8 @@ V2_S3_SECRET="${TGT_FULLNAME}-s3-auth"
 v1_pg_super() {
   local pw
   pw=$(secret_data "$NAMESPACE" "$V1_PG_SECRET" "$V1_PG_PW_KEY")
-  kx -n "$NAMESPACE" exec "${SRC_FULLNAME}-postgresql-0" -- env PGPASSWORD="$pw" psql -U postgres "$@"
+  kx_exec_with_secret_env "$NAMESPACE" "${SRC_FULLNAME}-postgresql-0" \
+    PGPASSWORD "$pw" psql -U postgres "$@"
 }
 
 # Chart Ingress is swapped automatically when values enable it, or when the
@@ -654,7 +691,15 @@ fi
 
 pg_exec_v2() {
   local su_pw=$1; shift
-  kx -n "$NAMESPACE" exec -i "${TGT_FULLNAME}-postgresql-0" -- env PGPASSWORD="$su_pw" psql -U postgres -d "$V2_PG_DB" "$@"
+  kx_exec_with_secret_env "$NAMESPACE" "${TGT_FULLNAME}-postgresql-0" \
+    PGPASSWORD "$su_pw" psql -U postgres -d "$V2_PG_DB" "$@"
+}
+
+pg_exec_v2_stdin() {
+  local su_pw=$1; shift
+  kx_exec_with_secret_env --forward-stdin "$NAMESPACE" \
+    "${TGT_FULLNAME}-postgresql-0" PGPASSWORD "$su_pw" \
+    psql -U postgres -d "$V2_PG_DB" "$@"
 }
 
 if [ "$PG_ON" -eq 1 ]; then
@@ -677,7 +722,7 @@ if [ "$PG_ON" -eq 1 ]; then
     # Password goes on stdin so it is not in the kubectl/psql argv.
     printf '%s\n' \
       "CREATE SUBSCRIPTION lf_sub CONNECTION 'host=${SRC_FULLNAME}-postgresql port=5432 dbname=${V1_PG_DB} user=postgres password=${V1_PW}' PUBLICATION lf_pub;" \
-      | pg_exec_v2 "$SU_PW"
+      | pg_exec_v2_stdin "$SU_PW"
   fi
   log "watching replication lag (Ctrl-C only stops the watch; re-run the script to continue)"
   for i in 1 2 3 4 5 6 7 8 9 10; do
@@ -694,6 +739,19 @@ ensure_mc_pod() {
   kx -n "$NAMESPACE" wait pod "$MC_POD" --for=condition=Ready --timeout=180s
 }
 
+mc_import_alias() {
+  local alias=$1 endpoint=$2 access_key=$3 secret_key=$4
+  printf '%s\0' "$endpoint" "$access_key" "$secret_key" \
+    | jq -Rs 'split("\u0000") | {
+        url: .[0],
+        accessKey: .[1],
+        secretKey: .[2],
+        api: "S3v4",
+        path: "auto"
+      }' \
+    | kx -n "$NAMESPACE" exec -i "$MC_POD" -- mc alias import "$alias"
+}
+
 mc_mirror() {
   local watch=$1
   local v1_key v1_secret v2_key v2_secret extra
@@ -704,8 +762,8 @@ mc_mirror() {
   extra=""
   [ "$watch" = "watch" ] && extra="--watch"
   ensure_mc_pod
-  kx -n "$NAMESPACE" exec "$MC_POD" -- mc alias set v1 "http://${V1_S3_SVC}" "$v1_key" "$v1_secret"
-  kx -n "$NAMESPACE" exec "$MC_POD" -- mc alias set v2 "http://${V2_S3_SVC}" "$v2_key" "$v2_secret"
+  mc_import_alias v1 "http://${V1_S3_SVC}" "$v1_key" "$v1_secret"
+  mc_import_alias v2 "http://${V2_S3_SVC}" "$v2_key" "$v2_secret"
   kx -n "$NAMESPACE" exec "$MC_POD" -- mc mb --ignore-existing "v2/${S3_BUCKET}"
   log "mc mirror v1/${S3_BUCKET} → v2/${S3_BUCKET} ${extra}"
   kx -n "$NAMESPACE" exec "$MC_POD" -- mc mirror --overwrite $extra "v1/${S3_BUCKET}" "v2/${S3_BUCKET}"
@@ -763,19 +821,18 @@ v1_redis_pod() {
 
 v1_queue_depth() {
   local pod=$1 pw=$2
-  kx -n "$NAMESPACE" exec "$pod" -- sh -c "
-    export REDISCLI_AUTH=$(printf '%q' "$pw")
+  kx_exec_with_secret_env "$NAMESPACE" "$pod" REDISCLI_AUTH "$pw" sh -c '
     depth=0
-    for k in \$(redis-cli --no-auth-warning --scan --pattern 'bull:*:wait' ; redis-cli --no-auth-warning --scan --pattern 'bull:*:active'); do
-      n=\$(redis-cli --no-auth-warning LLEN \"\$k\" 2>/dev/null || echo 0)
-      depth=\$((depth + \${n:-0}))
+    for k in $(redis-cli --no-auth-warning --scan --pattern "bull:*:wait"; redis-cli --no-auth-warning --scan --pattern "bull:*:active"); do
+      n=$(redis-cli --no-auth-warning LLEN "$k" 2>/dev/null || echo 0)
+      depth=$((depth + ${n:-0}))
     done
-    for k in \$(redis-cli --no-auth-warning --scan --pattern 'bull:*:delayed'); do
-      n=\$(redis-cli --no-auth-warning ZCARD \"\$k\" 2>/dev/null || echo 0)
-      depth=\$((depth + \${n:-0}))
+    for k in $(redis-cli --no-auth-warning --scan --pattern "bull:*:delayed"); do
+      n=$(redis-cli --no-auth-warning ZCARD "$k" 2>/dev/null || echo 0)
+      depth=$((depth + ${n:-0}))
     done
-    echo \$depth
-  " | tr -d '[:space:]'
+    echo "$depth"
+  ' | tr -d '[:space:]'
 }
 
 drain_v1_queues() {


### PR DESCRIPTION
## Summary

- stream PostgreSQL and Redis credentials through `kubectl exec -i` instead of embedding them in remote process arguments
- stream the ClickHouse target password and `remote()` query through stdin, using `CLICKHOUSE_PASSWORD` only inside the target container
- import MinIO aliases from JSON on stdin instead of passing access and secret keys to `mc alias set`
- remove manual documentation examples that placed migration credentials in command arguments

The migration sequence and data-copy behavior are unchanged. The transport is length-framed so secrets containing spaces, quotes, or trailing newlines are preserved while any following SQL remains available on stdin.

## Why

Command arguments can be exposed through process listings, shell history, audit records, and command diagnostics. The v1-to-v2 migration handles database and object-store credentials, so those values should never be present in `kubectl`, `psql`, `clickhouse-client`, `redis-cli`, or `mc` argument vectors.

## Verification

- `bash -n` passes for both modified scripts
- ShellCheck reports no errors; remaining warnings are pre-existing or intentional remote-shell expansion notices
- fake-`kubectl` transport tests preserve spaces, quotes, and trailing newlines while proving the secret is absent from both local and remote argument vectors
- ClickHouse transport test proves both target and source credentials are absent from the `kubectl` and `clickhouse-client` argument vectors
- the exact JSON-over-stdin pipeline imports successfully with the official `minio/mc` container
