### PR TITLE
feat: first-class Langfuse AI feature values (LFE-15741)

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ langfuse:
 
 `egressNetworkConnectorArn` is required with the `lambda-microvm` provider: without it AWS attaches its default `INTERNET_EGRESS` connector and sandboxed code reaches the public internet.
 
-`mcp.useInternalWebUrl` points the worker's MCP calls at the in-cluster web Service. It sets `LANGFUSE_MCP_BASE_URL` and leaves `NEXTAUTH_URL` alone, because the worker also builds links for users out of `NEXTAUTH_URL` in batch export emails and Slack notifications.
+`mcp.useInternalWebUrl` points the worker's MCP calls at the in-cluster web Service. It sets `LANGFUSE_MCP_BASE_URL` and leaves `NEXTAUTH_URL` alone, because the worker also builds links for users out of `NEXTAUTH_URL` in batch export emails and Slack notifications. This one value requires Langfuse `>= 4.25`; the rest of the block works on `>= 4.24`.
 
 #### Storage Provider Options
 

--- a/README.md
+++ b/README.md
@@ -252,6 +252,36 @@ s3:
 
 See the [Helm README](https://github.com/langfuse/langfuse-k8s/blob/main/charts/langfuse/README.md) for a full list of all configuration options.
 
+#### Langfuse AI features
+
+The AI features — the in-app agent and Ask AI — run on one instance-wide Langfuse AI model. Requires Langfuse `>= 4.24` (`langfuse.image.tag`). Set `langfuse.aiFeatures.provider` and `langfuse.aiFeatures.model`.
+
+Helm does not create AWS Lambda MicroVM resources for the agent's code execution sandbox — either let [langfuse-terraform-aws](https://github.com/langfuse/langfuse-terraform-aws) create them, or create them by hand and pass the ARNs into `langfuse.aiFeatures.inAppAgent.sandbox`. See the [self-hosted docs](https://langfuse.com/self-hosting/configuration/langfuse-assistant).
+
+```yaml
+langfuse:
+  image:
+    tag: "4.24.0" # or newer
+  aiFeatures:
+    provider: bedrock
+    model: eu.anthropic.claude-opus-5
+    bedrockRegion: eu-west-1
+    inAppAgent:
+      enabled: true
+      mcp:
+        useInternalWebUrl: true
+      sandbox:
+        provider: lambda-microvm
+        imageIdentifier: arn:aws:lambda:eu-west-1:123456789012:microvm-image:langfuse-in-app-agent-sandbox
+        executionRoleArn: arn:aws:iam::123456789012:role/langfuse-agent-sandbox-execution
+        region: eu-west-1
+        egressNetworkConnectorArn: arn:aws:lambda:eu-west-1:123456789012:network-connector:langfuse-agent-sandbox-egress
+```
+
+`egressNetworkConnectorArn` is required with the `lambda-microvm` provider: without it AWS attaches its default `INTERNET_EGRESS` connector and sandboxed code reaches the public internet.
+
+`mcp.useInternalWebUrl` points the worker's MCP calls at the in-cluster web Service. It sets `LANGFUSE_MCP_BASE_URL` and leaves `NEXTAUTH_URL` alone, because the worker also builds links for users out of `NEXTAUTH_URL` in batch export emails and Slack notifications.
+
 #### Storage Provider Options
 
 Langfuse supports multiple blob storage providers through the `s3.storageProvider` configuration:

--- a/charts/langfuse/Chart.yaml
+++ b/charts/langfuse/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: langfuse
-version: 2.0.3
+version: 2.1.0
 description: Open source LLM engineering platform - LLM observability, metrics, evaluations, prompt management.
 type: application
 keywords:

--- a/charts/langfuse/README.md
+++ b/charts/langfuse/README.md
@@ -1,6 +1,6 @@
 # langfuse
 
-![Version: 2.0.3](https://img.shields.io/badge/Version-2.0.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.24.0](https://img.shields.io/badge/AppVersion-4.24.0-informational?style=flat-square)
+![Version: 2.1.0](https://img.shields.io/badge/Version-2.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.17.0](https://img.shields.io/badge/AppVersion-4.17.0-informational?style=flat-square)
 
 Open source LLM engineering platform - LLM observability, metrics, evaluations, prompt management.
 
@@ -73,6 +73,23 @@ Open source LLM engineering platform - LLM observability, metrics, evaluations, 
 | langfuse.additionalEnv | list | `[]` | List of additional environment variables to be added to all langfuse deployments. See [documentation](https://langfuse.com/docs/deployment/self-host#configuring-environment-variables) for details. |
 | langfuse.additionalEnvFrom | list | `[]` | Secrets or ConfigMap of additional environment variables to be added to all langfuse deployments. See [documentation](https://langfuse.com/docs/deployment/self-host#configuring-environment-variables) for details. |
 | langfuse.affinity | object | `{}` | Affinity for all langfuse deployments |
+| langfuse.aiFeatures | object | `{"apiKey":{"secretKeyRef":{"key":"","name":""},"value":""},"baseUrl":"","bedrockRegion":"","extraHeaders":"","inAppAgent":{"enabled":false,"mcp":{"useInternalWebUrl":false},"sandbox":{"egressNetworkConnectorArn":"","executionRoleArn":"","imageIdentifier":"","provider":"","region":""}},"model":"","projectId":"","provider":"","smallModel":"","useResponsesApi":false}` | Langfuse AI features: the in-app agent and Ask AI. One instance-wide Langfuse AI model powers both. Requires application version >= 4.24. Helm does not create AWS Lambda MicroVM resources; pass ARNs from Terraform or a manual AWS setup. See https://langfuse.com/self-hosting/configuration/langfuse-assistant |
+| langfuse.aiFeatures.apiKey | object | `{"secretKeyRef":{"key":"","name":""},"value":""}` | LANGFUSE_AI_API_KEY (anthropic and openai). Prefer secretKeyRef. |
+| langfuse.aiFeatures.baseUrl | string | `""` | LANGFUSE_AI_BASE_URL. For openai, include `/v1`. |
+| langfuse.aiFeatures.bedrockRegion | string | `""` | LANGFUSE_AI_AWS_BEDROCK_REGION |
+| langfuse.aiFeatures.extraHeaders | string | `""` | LANGFUSE_AI_EXTRA_HEADERS as a JSON object string |
+| langfuse.aiFeatures.inAppAgent.enabled | bool | `false` | Set to `true` to set LANGFUSE_IN_APP_AGENT_ENABLED on web and worker |
+| langfuse.aiFeatures.inAppAgent.mcp.useInternalWebUrl | bool | `false` | Point the worker's MCP calls at the in-cluster web Service and allow that Host on web. Sets LANGFUSE_MCP_BASE_URL, so the externally resolvable NEXTAUTH_URL is left alone; the worker also builds email and Slack links from it. Requires a Langfuse version that supports LANGFUSE_MCP_BASE_URL. |
+| langfuse.aiFeatures.inAppAgent.sandbox.egressNetworkConnectorArn | string | `""` | LANGFUSE_IN_APP_AGENT_SANDBOX_AWS_LAMBDA_MICROVM_EGRESS_NETWORK_CONNECTOR_ARN. Required with the lambda-microvm provider: without it AWS attaches its default INTERNET_EGRESS connector and sandboxed code reaches the public internet. |
+| langfuse.aiFeatures.inAppAgent.sandbox.executionRoleArn | string | `""` | LANGFUSE_IN_APP_AGENT_SANDBOX_AWS_LAMBDA_MICROVM_EXECUTION_ROLE_ARN |
+| langfuse.aiFeatures.inAppAgent.sandbox.imageIdentifier | string | `""` | LANGFUSE_IN_APP_AGENT_SANDBOX_AWS_LAMBDA_MICROVM_IMAGE_IDENTIFIER |
+| langfuse.aiFeatures.inAppAgent.sandbox.provider | string | `""` | LANGFUSE_IN_APP_AGENT_SANDBOX_PROVIDER. Use `lambda-microvm` on AWS. Leave empty for Langfuse tools only. |
+| langfuse.aiFeatures.inAppAgent.sandbox.region | string | `""` | LANGFUSE_IN_APP_AGENT_SANDBOX_AWS_LAMBDA_MICROVM_REGION |
+| langfuse.aiFeatures.model | string | `""` | LANGFUSE_AI_MODEL. Required whenever provider is set. |
+| langfuse.aiFeatures.projectId | string | `""` | LANGFUSE_AI_FEATURES_PROJECT_ID for tracing AI feature runs on this instance |
+| langfuse.aiFeatures.provider | string | `""` | LANGFUSE_AI_PROVIDER: bedrock, anthropic, or openai. Required to enable the AI features; there is no default. |
+| langfuse.aiFeatures.smallModel | string | `""` | LANGFUSE_AI_SMALL_MODEL for supplementary calls such as conversation titles |
+| langfuse.aiFeatures.useResponsesApi | bool | `false` | Set LANGFUSE_AI_USE_RESPONSES_API=true for the OpenAI Responses API |
 | langfuse.allowV1Upgrade | bool | `false` | Allow helm upgrade that would replace leftover v1 Bitnami stores (CH STS, PG PVC, MinIO Deploy) with empty v2 volumes. Default false. The supported path is examples/upgrade-v1-to-v2 (in-place only when stores are external; otherwise a sibling v2 release). |
 | langfuse.allowedOrganizationCreators | list | `[]` | EE: Langfuse allowed organization creators. See [documentation](https://langfuse.com/self-hosting/organization-creators) |
 | langfuse.deployment.annotations | object | `{}` | Annotations for all langfuse deployments |

--- a/charts/langfuse/README.md
+++ b/charts/langfuse/README.md
@@ -74,7 +74,7 @@ Open source LLM engineering platform - LLM observability, metrics, evaluations, 
 | langfuse.additionalEnvFrom | list | `[]` | Secrets or ConfigMap of additional environment variables to be added to all langfuse deployments. See [documentation](https://langfuse.com/docs/deployment/self-host#configuring-environment-variables) for details. |
 | langfuse.affinity | object | `{}` | Affinity for all langfuse deployments |
 | langfuse.aiFeatures | object | `{"apiKey":{"secretKeyRef":{"key":"","name":""},"value":""},"baseUrl":"","bedrockRegion":"","extraHeaders":"","inAppAgent":{"enabled":false,"mcp":{"useInternalWebUrl":false},"sandbox":{"egressNetworkConnectorArn":"","executionRoleArn":"","imageIdentifier":"","provider":"","region":""}},"model":"","projectId":"","provider":"","smallModel":"","useResponsesApi":false}` | Langfuse AI features: the in-app agent and Ask AI. One instance-wide Langfuse AI model powers both. Requires application version >= 4.24. Helm does not create AWS Lambda MicroVM resources; pass ARNs from Terraform or a manual AWS setup. See https://langfuse.com/self-hosting/configuration/langfuse-assistant |
-| langfuse.aiFeatures.apiKey | object | `{"secretKeyRef":{"key":"","name":""},"value":""}` | LANGFUSE_AI_API_KEY (anthropic and openai). Prefer secretKeyRef. |
+| langfuse.aiFeatures.apiKey | object | `{"secretKeyRef":{"key":"","name":""},"value":""}` | LANGFUSE_AI_API_KEY. Required for anthropic and openai; rejected for bedrock, which authenticates through the AWS credential chain. Prefer secretKeyRef. |
 | langfuse.aiFeatures.baseUrl | string | `""` | LANGFUSE_AI_BASE_URL. For openai, include `/v1`. |
 | langfuse.aiFeatures.bedrockRegion | string | `""` | LANGFUSE_AI_AWS_BEDROCK_REGION |
 | langfuse.aiFeatures.extraHeaders | string | `""` | LANGFUSE_AI_EXTRA_HEADERS as a JSON object string |
@@ -87,7 +87,7 @@ Open source LLM engineering platform - LLM observability, metrics, evaluations, 
 | langfuse.aiFeatures.inAppAgent.sandbox.region | string | `""` | LANGFUSE_IN_APP_AGENT_SANDBOX_AWS_LAMBDA_MICROVM_REGION |
 | langfuse.aiFeatures.model | string | `""` | LANGFUSE_AI_MODEL. Required whenever provider is set. |
 | langfuse.aiFeatures.projectId | string | `""` | LANGFUSE_AI_FEATURES_PROJECT_ID for tracing AI feature runs on this instance |
-| langfuse.aiFeatures.provider | string | `""` | LANGFUSE_AI_PROVIDER: bedrock, anthropic, or openai. Required to enable the AI features; there is no default. |
+| langfuse.aiFeatures.provider | string | `""` | LANGFUSE_AI_PROVIDER: bedrock, anthropic, or openai. Required to enable the AI features; there is no default. Must be set together with model. |
 | langfuse.aiFeatures.smallModel | string | `""` | LANGFUSE_AI_SMALL_MODEL for supplementary calls such as conversation titles |
 | langfuse.aiFeatures.useResponsesApi | bool | `false` | Set LANGFUSE_AI_USE_RESPONSES_API=true for the OpenAI Responses API |
 | langfuse.allowV1Upgrade | bool | `false` | Allow helm upgrade that would replace leftover v1 Bitnami stores (CH STS, PG PVC, MinIO Deploy) with empty v2 volumes. Default false. The supported path is examples/upgrade-v1-to-v2 (in-place only when stores are external; otherwise a sibling v2 release). |

--- a/charts/langfuse/README.md
+++ b/charts/langfuse/README.md
@@ -83,7 +83,7 @@ Open source LLM engineering platform - LLM observability, metrics, evaluations, 
 | langfuse.aiFeatures.inAppAgent.sandbox.egressNetworkConnectorArn | string | `""` | LANGFUSE_IN_APP_AGENT_SANDBOX_AWS_LAMBDA_MICROVM_EGRESS_NETWORK_CONNECTOR_ARN. Required with the lambda-microvm provider: without it AWS attaches its default INTERNET_EGRESS connector and sandboxed code reaches the public internet. |
 | langfuse.aiFeatures.inAppAgent.sandbox.executionRoleArn | string | `""` | LANGFUSE_IN_APP_AGENT_SANDBOX_AWS_LAMBDA_MICROVM_EXECUTION_ROLE_ARN |
 | langfuse.aiFeatures.inAppAgent.sandbox.imageIdentifier | string | `""` | LANGFUSE_IN_APP_AGENT_SANDBOX_AWS_LAMBDA_MICROVM_IMAGE_IDENTIFIER |
-| langfuse.aiFeatures.inAppAgent.sandbox.provider | string | `""` | LANGFUSE_IN_APP_AGENT_SANDBOX_PROVIDER. Use `lambda-microvm` on AWS. Leave empty for Langfuse tools only. |
+| langfuse.aiFeatures.inAppAgent.sandbox.provider | string | `""` | LANGFUSE_IN_APP_AGENT_SANDBOX_PROVIDER. `lambda-microvm` is the only accepted value; leave empty for Langfuse tools only. The application also has a `dangerous-docker` provider, but it refuses to start unless NODE_ENV=development, so it is not usable here. |
 | langfuse.aiFeatures.inAppAgent.sandbox.region | string | `""` | LANGFUSE_IN_APP_AGENT_SANDBOX_AWS_LAMBDA_MICROVM_REGION |
 | langfuse.aiFeatures.model | string | `""` | LANGFUSE_AI_MODEL. Required whenever provider is set. |
 | langfuse.aiFeatures.projectId | string | `""` | LANGFUSE_AI_FEATURES_PROJECT_ID for tracing AI feature runs on this instance |

--- a/charts/langfuse/README.md
+++ b/charts/langfuse/README.md
@@ -1,6 +1,6 @@
 # langfuse
 
-![Version: 2.1.0](https://img.shields.io/badge/Version-2.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.17.0](https://img.shields.io/badge/AppVersion-4.17.0-informational?style=flat-square)
+![Version: 2.1.0](https://img.shields.io/badge/Version-2.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.24.0](https://img.shields.io/badge/AppVersion-4.24.0-informational?style=flat-square)
 
 Open source LLM engineering platform - LLM observability, metrics, evaluations, prompt management.
 
@@ -79,7 +79,7 @@ Open source LLM engineering platform - LLM observability, metrics, evaluations, 
 | langfuse.aiFeatures.bedrockRegion | string | `""` | LANGFUSE_AI_AWS_BEDROCK_REGION |
 | langfuse.aiFeatures.extraHeaders | string | `""` | LANGFUSE_AI_EXTRA_HEADERS as a JSON object string |
 | langfuse.aiFeatures.inAppAgent.enabled | bool | `false` | Set to `true` to set LANGFUSE_IN_APP_AGENT_ENABLED on web and worker |
-| langfuse.aiFeatures.inAppAgent.mcp.useInternalWebUrl | bool | `false` | Point the worker's MCP calls at the in-cluster web Service and allow that Host on web. Sets LANGFUSE_MCP_BASE_URL, so the externally resolvable NEXTAUTH_URL is left alone; the worker also builds email and Slack links from it. Requires a Langfuse version that supports LANGFUSE_MCP_BASE_URL. |
+| langfuse.aiFeatures.inAppAgent.mcp.useInternalWebUrl | bool | `false` | Point the worker's MCP calls at the in-cluster web Service and allow that Host on web. Sets LANGFUSE_MCP_BASE_URL, so the externally resolvable NEXTAUTH_URL is left alone; the worker also builds email and Slack links from it. Requires application version >= 4.25, unlike the rest of this block; on 4.24 the worker ignores it and falls back to NEXTAUTH_URL. |
 | langfuse.aiFeatures.inAppAgent.sandbox.egressNetworkConnectorArn | string | `""` | LANGFUSE_IN_APP_AGENT_SANDBOX_AWS_LAMBDA_MICROVM_EGRESS_NETWORK_CONNECTOR_ARN. Required with the lambda-microvm provider: without it AWS attaches its default INTERNET_EGRESS connector and sandboxed code reaches the public internet. |
 | langfuse.aiFeatures.inAppAgent.sandbox.executionRoleArn | string | `""` | LANGFUSE_IN_APP_AGENT_SANDBOX_AWS_LAMBDA_MICROVM_EXECUTION_ROLE_ARN |
 | langfuse.aiFeatures.inAppAgent.sandbox.imageIdentifier | string | `""` | LANGFUSE_IN_APP_AGENT_SANDBOX_AWS_LAMBDA_MICROVM_IMAGE_IDENTIFIER |

--- a/charts/langfuse/README.md
+++ b/charts/langfuse/README.md
@@ -83,7 +83,7 @@ Open source LLM engineering platform - LLM observability, metrics, evaluations, 
 | langfuse.aiFeatures.inAppAgent.sandbox.egressNetworkConnectorArn | string | `""` | LANGFUSE_IN_APP_AGENT_SANDBOX_AWS_LAMBDA_MICROVM_EGRESS_NETWORK_CONNECTOR_ARN. Required with the lambda-microvm provider: without it AWS attaches its default INTERNET_EGRESS connector and sandboxed code reaches the public internet. |
 | langfuse.aiFeatures.inAppAgent.sandbox.executionRoleArn | string | `""` | LANGFUSE_IN_APP_AGENT_SANDBOX_AWS_LAMBDA_MICROVM_EXECUTION_ROLE_ARN |
 | langfuse.aiFeatures.inAppAgent.sandbox.imageIdentifier | string | `""` | LANGFUSE_IN_APP_AGENT_SANDBOX_AWS_LAMBDA_MICROVM_IMAGE_IDENTIFIER |
-| langfuse.aiFeatures.inAppAgent.sandbox.provider | string | `""` | LANGFUSE_IN_APP_AGENT_SANDBOX_PROVIDER. `lambda-microvm` is the only accepted value; leave empty for Langfuse tools only. The application also has a `dangerous-docker` provider, but it refuses to start unless NODE_ENV=development, so it is not usable here. |
+| langfuse.aiFeatures.inAppAgent.sandbox.provider | string | `""` | LANGFUSE_IN_APP_AGENT_SANDBOX_PROVIDER. `lambda-microvm` is the only accepted value; leave empty for Langfuse tools only. The application also has a development-only `dangerous-docker` provider, which is not usable in a deployed instance. |
 | langfuse.aiFeatures.inAppAgent.sandbox.region | string | `""` | LANGFUSE_IN_APP_AGENT_SANDBOX_AWS_LAMBDA_MICROVM_REGION |
 | langfuse.aiFeatures.model | string | `""` | LANGFUSE_AI_MODEL. Required whenever provider is set. |
 | langfuse.aiFeatures.projectId | string | `""` | LANGFUSE_AI_FEATURES_PROJECT_ID for tracing AI feature runs on this instance |

--- a/charts/langfuse/templates/_helpers.tpl
+++ b/charts/langfuse/templates/_helpers.tpl
@@ -809,6 +809,108 @@ Return ClickHouse protocol (http or https)
 {{- end -}}
 
 {{/*
+Langfuse AI features: the instance-wide model plus the in-app agent switch.
+Applied to web and worker; both call the model, web for Ask AI and conversation
+titles and worker for agent runs. Requires Langfuse >= 4.24. See
+https://langfuse.com/self-hosting/configuration/langfuse-assistant
+*/}}
+{{- define "langfuse.aiFeaturesEnv" -}}
+{{- $ai := .Values.langfuse.aiFeatures | default dict -}}
+{{- $agent := $ai.inAppAgent | default dict -}}
+{{- if $agent.enabled }}
+- name: LANGFUSE_IN_APP_AGENT_ENABLED
+  value: "true"
+{{- end }}
+{{- if $ai.provider }}
+- name: LANGFUSE_AI_PROVIDER
+  value: {{ $ai.provider | quote }}
+{{- end }}
+{{- if $ai.model }}
+- name: LANGFUSE_AI_MODEL
+  value: {{ $ai.model | quote }}
+{{- end }}
+{{- if $ai.smallModel }}
+- name: LANGFUSE_AI_SMALL_MODEL
+  value: {{ $ai.smallModel | quote }}
+{{- end }}
+{{- if $ai.apiKey }}
+{{- with (include "langfuse.getValueOrSecret" (dict "key" "langfuse.aiFeatures.apiKey" "value" $ai.apiKey)) }}
+- name: LANGFUSE_AI_API_KEY
+  {{- . | nindent 2 }}
+{{- end }}
+{{- end }}
+{{- if $ai.baseUrl }}
+- name: LANGFUSE_AI_BASE_URL
+  value: {{ $ai.baseUrl | quote }}
+{{- end }}
+{{- if $ai.extraHeaders }}
+- name: LANGFUSE_AI_EXTRA_HEADERS
+  value: {{ $ai.extraHeaders | quote }}
+{{- end }}
+{{- if $ai.useResponsesApi }}
+- name: LANGFUSE_AI_USE_RESPONSES_API
+  value: "true"
+{{- end }}
+{{- if $ai.bedrockRegion }}
+- name: LANGFUSE_AI_AWS_BEDROCK_REGION
+  value: {{ $ai.bedrockRegion | quote }}
+{{- end }}
+{{- if $ai.projectId }}
+- name: LANGFUSE_AI_FEATURES_PROJECT_ID
+  value: {{ $ai.projectId | quote }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Worker-only Lambda MicroVM sandbox variables. Helm does not create AWS resources.
+*/}}
+{{- define "langfuse.agentSandboxEnv" -}}
+{{- $s := (((.Values.langfuse.aiFeatures | default dict).inAppAgent | default dict).sandbox | default dict) -}}
+{{- if $s.provider }}
+- name: LANGFUSE_IN_APP_AGENT_SANDBOX_PROVIDER
+  value: {{ $s.provider | quote }}
+{{- end }}
+{{- if $s.imageIdentifier }}
+- name: LANGFUSE_IN_APP_AGENT_SANDBOX_AWS_LAMBDA_MICROVM_IMAGE_IDENTIFIER
+  value: {{ $s.imageIdentifier | quote }}
+{{- end }}
+{{- if $s.executionRoleArn }}
+- name: LANGFUSE_IN_APP_AGENT_SANDBOX_AWS_LAMBDA_MICROVM_EXECUTION_ROLE_ARN
+  value: {{ $s.executionRoleArn | quote }}
+{{- end }}
+{{- if $s.region }}
+- name: LANGFUSE_IN_APP_AGENT_SANDBOX_AWS_LAMBDA_MICROVM_REGION
+  value: {{ $s.region | quote }}
+{{- end }}
+{{- if $s.egressNetworkConnectorArn }}
+- name: LANGFUSE_IN_APP_AGENT_SANDBOX_AWS_LAMBDA_MICROVM_EGRESS_NETWORK_CONNECTOR_ARN
+  value: {{ $s.egressNetworkConnectorArn | quote }}
+{{- end }}
+{{- end -}}
+
+{{/*
+In-cluster MCP: the worker calls the web Service instead of the public URL.
+Scoped to LANGFUSE_MCP_BASE_URL rather than NEXTAUTH_URL, which the worker also
+uses to build links for users in emails and Slack messages and which therefore
+has to stay externally resolvable.
+*/}}
+{{- define "langfuse.aiFeaturesMcpWebEnv" -}}
+{{- $mcp := (((.Values.langfuse.aiFeatures | default dict).inAppAgent | default dict).mcp | default dict) -}}
+{{- if $mcp.useInternalWebUrl }}
+- name: LANGFUSE_MCP_ALLOWED_HOSTS
+  value: {{ printf "%s-web" (include "langfuse.fullname" .) | quote }}
+{{- end }}
+{{- end -}}
+
+{{- define "langfuse.aiFeaturesMcpWorkerEnv" -}}
+{{- $mcp := (((.Values.langfuse.aiFeatures | default dict).inAppAgent | default dict).mcp | default dict) -}}
+{{- if $mcp.useInternalWebUrl }}
+- name: LANGFUSE_MCP_BASE_URL
+  value: {{ printf "http://%s-web:%v" (include "langfuse.fullname" .) (.Values.langfuse.web.service.port) | quote }}
+{{- end }}
+{{- end -}}
+
+{{/*
 Common environment variables for all deployments
 */}}
 {{- define "langfuse.commonEnv" -}}
@@ -818,4 +920,5 @@ Common environment variables for all deployments
 {{ include "langfuse.redisEnv" . }}
 {{ include "langfuse.clickhouseEnv" . }}
 {{ include "langfuse.s3Env" . }}
+{{ include "langfuse.aiFeaturesEnv" . }}
 {{- end -}}

--- a/charts/langfuse/templates/validations.yaml
+++ b/charts/langfuse/templates/validations.yaml
@@ -379,6 +379,9 @@ what you are doing.
     {{- fail "langfuse.aiFeatures.provider and langfuse.aiFeatures.model are required when langfuse.aiFeatures.inAppAgent.enabled is true" -}}
 {{- end -}}
 {{- $sandbox := $inAppAgent.sandbox | default dict -}}
+{{- if and $sandbox.provider (ne $sandbox.provider "lambda-microvm") -}}
+    {{- fail "langfuse.aiFeatures.inAppAgent.sandbox.provider must be lambda-microvm. The application also accepts dangerous-docker, but refuses it unless NODE_ENV=development, so it cannot work in a chart deployment." -}}
+{{- end -}}
 {{- if eq ($sandbox.provider | default "") "lambda-microvm" -}}
 {{- if or (not $sandbox.imageIdentifier) (not $sandbox.executionRoleArn) (not $sandbox.region) -}}
     {{- fail "langfuse.aiFeatures.inAppAgent.sandbox.imageIdentifier, executionRoleArn, and region are required when sandbox.provider is lambda-microvm" -}}

--- a/charts/langfuse/templates/validations.yaml
+++ b/charts/langfuse/templates/validations.yaml
@@ -357,8 +357,23 @@ what you are doing.
 
 {{- $aiFeatures := .Values.langfuse.aiFeatures | default dict -}}
 {{- $inAppAgent := $aiFeatures.inAppAgent | default dict -}}
+{{- $apiKey := $aiFeatures.apiKey | default dict -}}
+{{- $apiKeyRef := $apiKey.secretKeyRef | default dict -}}
+{{- $apiKeySet := or $apiKey.value $apiKeyRef.name -}}
+{{- if and $aiFeatures.provider (not (has $aiFeatures.provider (list "bedrock" "anthropic" "openai"))) -}}
+    {{- fail "langfuse.aiFeatures.provider must be one of bedrock, anthropic, or openai" -}}
+{{- end -}}
 {{- if and $aiFeatures.provider (not $aiFeatures.model) -}}
     {{- fail "langfuse.aiFeatures.model is required when langfuse.aiFeatures.provider is set" -}}
+{{- end -}}
+{{- if and $aiFeatures.model (not $aiFeatures.provider) -}}
+    {{- fail "langfuse.aiFeatures.provider is required when langfuse.aiFeatures.model is set. Without it the model is ignored and the AI features report as unconfigured." -}}
+{{- end -}}
+{{- if and (has ($aiFeatures.provider | default "") (list "anthropic" "openai")) (not $apiKeySet) -}}
+    {{- fail "langfuse.aiFeatures.apiKey is required for the anthropic and openai providers. Set apiKey.secretKeyRef, or apiKey.value." -}}
+{{- end -}}
+{{- if and (eq ($aiFeatures.provider | default "") "bedrock") $apiKeySet -}}
+    {{- fail "langfuse.aiFeatures.apiKey is not used by the bedrock provider, which authenticates through the AWS credential chain. Remove it, or switch provider." -}}
 {{- end -}}
 {{- if and $inAppAgent.enabled (not $aiFeatures.model) -}}
     {{- fail "langfuse.aiFeatures.provider and langfuse.aiFeatures.model are required when langfuse.aiFeatures.inAppAgent.enabled is true" -}}

--- a/charts/langfuse/templates/validations.yaml
+++ b/charts/langfuse/templates/validations.yaml
@@ -354,3 +354,21 @@ what you are doing.
 {{- if and $workerPdb.create $workerMinAvailableSet $workerMaxUnavailableSet -}}
     {{- fail "Pod Disruption Budget for worker component cannot have both minAvailable and maxUnavailable values" -}}
 {{- end -}}
+
+{{- $aiFeatures := .Values.langfuse.aiFeatures | default dict -}}
+{{- $inAppAgent := $aiFeatures.inAppAgent | default dict -}}
+{{- if and $aiFeatures.provider (not $aiFeatures.model) -}}
+    {{- fail "langfuse.aiFeatures.model is required when langfuse.aiFeatures.provider is set" -}}
+{{- end -}}
+{{- if and $inAppAgent.enabled (not $aiFeatures.model) -}}
+    {{- fail "langfuse.aiFeatures.provider and langfuse.aiFeatures.model are required when langfuse.aiFeatures.inAppAgent.enabled is true" -}}
+{{- end -}}
+{{- $sandbox := $inAppAgent.sandbox | default dict -}}
+{{- if eq ($sandbox.provider | default "") "lambda-microvm" -}}
+{{- if or (not $sandbox.imageIdentifier) (not $sandbox.executionRoleArn) (not $sandbox.region) -}}
+    {{- fail "langfuse.aiFeatures.inAppAgent.sandbox.imageIdentifier, executionRoleArn, and region are required when sandbox.provider is lambda-microvm" -}}
+{{- end -}}
+{{- if not $sandbox.egressNetworkConnectorArn -}}
+    {{- fail "langfuse.aiFeatures.inAppAgent.sandbox.egressNetworkConnectorArn is required when sandbox.provider is lambda-microvm. Without it AWS attaches its default INTERNET_EGRESS connector and sandboxed code reaches the public internet. Set it to a VPC egress connector with a deny-all security group." -}}
+{{- end -}}
+{{- end -}}

--- a/charts/langfuse/templates/validations.yaml
+++ b/charts/langfuse/templates/validations.yaml
@@ -380,7 +380,7 @@ what you are doing.
 {{- end -}}
 {{- $sandbox := $inAppAgent.sandbox | default dict -}}
 {{- if and $sandbox.provider (ne $sandbox.provider "lambda-microvm") -}}
-    {{- fail "langfuse.aiFeatures.inAppAgent.sandbox.provider must be lambda-microvm. The application also accepts dangerous-docker, but refuses it unless NODE_ENV=development, so it cannot work in a chart deployment." -}}
+    {{- fail "langfuse.aiFeatures.inAppAgent.sandbox.provider must be lambda-microvm. dangerous-docker is a development-only provider and is not usable in a deployed instance." -}}
 {{- end -}}
 {{- if eq ($sandbox.provider | default "") "lambda-microvm" -}}
 {{- if or (not $sandbox.imageIdentifier) (not $sandbox.executionRoleArn) (not $sandbox.region) -}}

--- a/charts/langfuse/templates/web/deployment.yaml
+++ b/charts/langfuse/templates/web/deployment.yaml
@@ -76,6 +76,7 @@ spec:
             {{- include "langfuse.commonEnv" . | nindent 12 }}
             - name: PORT
               value: {{ .Values.langfuse.web.service.port | quote }}
+            {{- include "langfuse.aiFeaturesMcpWebEnv" . | nindent 12 }}
             {{- $additionalEnv := concat (.Values.langfuse.additionalEnv | default list ) (.Values.langfuse.web.pod.additionalEnv | default list )}}
             {{- if not (include "langfuse.getEnvVar" (dict "env" $additionalEnv "name" "HOSTNAME")) }}
             - name: HOSTNAME
@@ -84,7 +85,6 @@ spec:
             {{- with $additionalEnv }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
-            {{- include "langfuse.aiFeaturesMcpWebEnv" . | nindent 12 }}
           {{- $additionalEnvFrom := concat (.Values.langfuse.additionalEnvFrom | default list ) (.Values.langfuse.web.pod.additionalEnvFrom | default list )}}
           {{- with $additionalEnvFrom }}
           envFrom:

--- a/charts/langfuse/templates/web/deployment.yaml
+++ b/charts/langfuse/templates/web/deployment.yaml
@@ -84,6 +84,7 @@ spec:
             {{- with $additionalEnv }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
+            {{- include "langfuse.aiFeaturesMcpWebEnv" . | nindent 12 }}
           {{- $additionalEnvFrom := concat (.Values.langfuse.additionalEnvFrom | default list ) (.Values.langfuse.web.pod.additionalEnvFrom | default list )}}
           {{- with $additionalEnvFrom }}
           envFrom:

--- a/charts/langfuse/templates/worker/deployment.yaml
+++ b/charts/langfuse/templates/worker/deployment.yaml
@@ -74,6 +74,7 @@ spec:
           imagePullPolicy: {{ .Values.langfuse.worker.image.pullPolicy | default .Values.langfuse.image.pullPolicy }}
           env:
             {{- include "langfuse.commonEnv" . | nindent 12 }}
+            {{- include "langfuse.agentSandboxEnv" . | nindent 12 }}
             {{- $additionalEnv := concat (.Values.langfuse.additionalEnv | default list ) (.Values.langfuse.worker.pod.additionalEnv | default list )}}
             {{- if not (include "langfuse.getEnvVar" (dict "env" $additionalEnv "name" "HOSTNAME")) }}
             - name: HOSTNAME
@@ -82,6 +83,7 @@ spec:
             {{- with $additionalEnv }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
+            {{- include "langfuse.aiFeaturesMcpWorkerEnv" . | nindent 12 }}
           {{- $additionalEnvFrom := concat (.Values.langfuse.additionalEnvFrom | default list ) (.Values.langfuse.worker.pod.additionalEnvFrom | default list )}}
           {{- with $additionalEnvFrom }}
           envFrom:

--- a/charts/langfuse/templates/worker/deployment.yaml
+++ b/charts/langfuse/templates/worker/deployment.yaml
@@ -75,6 +75,7 @@ spec:
           env:
             {{- include "langfuse.commonEnv" . | nindent 12 }}
             {{- include "langfuse.agentSandboxEnv" . | nindent 12 }}
+            {{- include "langfuse.aiFeaturesMcpWorkerEnv" . | nindent 12 }}
             {{- $additionalEnv := concat (.Values.langfuse.additionalEnv | default list ) (.Values.langfuse.worker.pod.additionalEnv | default list )}}
             {{- if not (include "langfuse.getEnvVar" (dict "env" $additionalEnv "name" "HOSTNAME")) }}
             - name: HOSTNAME
@@ -83,7 +84,6 @@ spec:
             {{- with $additionalEnv }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
-            {{- include "langfuse.aiFeaturesMcpWorkerEnv" . | nindent 12 }}
           {{- $additionalEnvFrom := concat (.Values.langfuse.additionalEnvFrom | default list ) (.Values.langfuse.worker.pod.additionalEnvFrom | default list )}}
           {{- with $additionalEnvFrom }}
           envFrom:

--- a/charts/langfuse/tests/ai_features_test.yaml
+++ b/charts/langfuse/tests/ai_features_test.yaml
@@ -1,0 +1,160 @@
+suite: Langfuse AI features values
+templates:
+  - validations.yaml
+  - web/deployment.yaml
+  - worker/deployment.yaml
+tests:
+  - it: does not set AI feature env when unconfigured
+    values:
+      - ../values.lint.yaml
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LANGFUSE_IN_APP_AGENT_ENABLED
+            value: "true"
+        template: web/deployment.yaml
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LANGFUSE_IN_APP_AGENT_SANDBOX_PROVIDER
+            value: "lambda-microvm"
+        template: worker/deployment.yaml
+
+  - it: sets the model on web and worker and the sandbox only on worker
+    values:
+      - ../values.lint.yaml
+    set:
+      langfuse:
+        aiFeatures:
+          provider: bedrock
+          model: eu.anthropic.claude-opus-5
+          bedrockRegion: eu-west-1
+          inAppAgent:
+            enabled: true
+            sandbox:
+              provider: lambda-microvm
+              imageIdentifier: arn:aws:lambda:eu-west-1:123456789012:microvm-image:langfuse-in-app-agent-sandbox
+              executionRoleArn: arn:aws:iam::123456789012:role/sandbox-execution
+              region: eu-west-1
+              egressNetworkConnectorArn: arn:aws:lambda:eu-west-1:123456789012:network-connector:deny-all
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LANGFUSE_IN_APP_AGENT_ENABLED
+            value: "true"
+        template: web/deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LANGFUSE_AI_MODEL
+            value: eu.anthropic.claude-opus-5
+        template: worker/deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LANGFUSE_IN_APP_AGENT_SANDBOX_PROVIDER
+            value: lambda-microvm
+        template: worker/deployment.yaml
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LANGFUSE_IN_APP_AGENT_SANDBOX_PROVIDER
+            value: lambda-microvm
+        template: web/deployment.yaml
+
+  # NEXTAUTH_URL also builds user-facing email and Slack links, so the in-cluster
+  # MCP overlay must not touch it.
+  - it: points only the worker's MCP calls at the in-cluster web Service
+    values:
+      - ../values.lint.yaml
+    set:
+      langfuse:
+        nextauth:
+          url: https://langfuse.example.com
+        aiFeatures:
+          inAppAgent:
+            mcp:
+              useInternalWebUrl: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LANGFUSE_MCP_ALLOWED_HOSTS
+            value: RELEASE-NAME-langfuse-web
+        template: web/deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LANGFUSE_MCP_BASE_URL
+            value: http://RELEASE-NAME-langfuse-web:3000
+        template: worker/deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: NEXTAUTH_URL
+            value: https://langfuse.example.com
+        template: worker/deployment.yaml
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: NEXTAUTH_URL
+            value: http://RELEASE-NAME-langfuse-web:3000
+        template: worker/deployment.yaml
+
+  - it: fails when the sandbox has no egress connector, which would give it internet access
+    values:
+      - ../values.lint.yaml
+    set:
+      langfuse:
+        aiFeatures:
+          inAppAgent:
+            sandbox:
+              provider: lambda-microvm
+              imageIdentifier: arn:aws:lambda:eu-west-1:123456789012:microvm-image:img
+              executionRoleArn: arn:aws:iam::123456789012:role/sandbox-execution
+              region: eu-west-1
+    asserts:
+      - failedTemplate:
+          errorMessage: "langfuse.aiFeatures.inAppAgent.sandbox.egressNetworkConnectorArn is required when sandbox.provider is lambda-microvm. Without it AWS attaches its default INTERNET_EGRESS connector and sandboxed code reaches the public internet. Set it to a VPC egress connector with a deny-all security group."
+        template: validations.yaml
+
+  - it: fails when the sandbox provider is set without the required ARNs
+    values:
+      - ../values.lint.yaml
+    set:
+      langfuse:
+        aiFeatures:
+          inAppAgent:
+            sandbox:
+              provider: lambda-microvm
+    asserts:
+      - failedTemplate:
+          errorMessage: "langfuse.aiFeatures.inAppAgent.sandbox.imageIdentifier, executionRoleArn, and region are required when sandbox.provider is lambda-microvm"
+        template: validations.yaml
+
+  - it: fails when the in-app agent is enabled without a model
+    values:
+      - ../values.lint.yaml
+    set:
+      langfuse:
+        aiFeatures:
+          inAppAgent:
+            enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "langfuse.aiFeatures.provider and langfuse.aiFeatures.model are required when langfuse.aiFeatures.inAppAgent.enabled is true"
+        template: validations.yaml
+
+  - it: fails when a provider is set without a model
+    values:
+      - ../values.lint.yaml
+    set:
+      langfuse:
+        aiFeatures:
+          provider: bedrock
+    asserts:
+      - failedTemplate:
+          errorMessage: "langfuse.aiFeatures.model is required when langfuse.aiFeatures.provider is set"
+        template: validations.yaml

--- a/charts/langfuse/tests/ai_features_test.yaml
+++ b/charts/langfuse/tests/ai_features_test.yaml
@@ -103,6 +103,20 @@ tests:
             value: http://RELEASE-NAME-langfuse-web:3000
         template: worker/deployment.yaml
 
+  - it: rejects a sandbox provider the chart cannot run
+    values:
+      - ../values.lint.yaml
+    set:
+      langfuse:
+        aiFeatures:
+          inAppAgent:
+            sandbox:
+              provider: dangerous-docker
+    asserts:
+      - failedTemplate:
+          errorMessage: "langfuse.aiFeatures.inAppAgent.sandbox.provider must be lambda-microvm. The application also accepts dangerous-docker, but refuses it unless NODE_ENV=development, so it cannot work in a chart deployment."
+        template: validations.yaml
+
   - it: fails when the sandbox has no egress connector, which would give it internet access
     values:
       - ../values.lint.yaml

--- a/charts/langfuse/tests/ai_features_test.yaml
+++ b/charts/langfuse/tests/ai_features_test.yaml
@@ -114,7 +114,7 @@ tests:
               provider: dangerous-docker
     asserts:
       - failedTemplate:
-          errorMessage: "langfuse.aiFeatures.inAppAgent.sandbox.provider must be lambda-microvm. The application also accepts dangerous-docker, but refuses it unless NODE_ENV=development, so it cannot work in a chart deployment."
+          errorMessage: "langfuse.aiFeatures.inAppAgent.sandbox.provider must be lambda-microvm. dangerous-docker is a development-only provider and is not usable in a deployed instance."
         template: validations.yaml
 
   - it: fails when the sandbox has no egress connector, which would give it internet access

--- a/charts/langfuse/tests/ai_features_test.yaml
+++ b/charts/langfuse/tests/ai_features_test.yaml
@@ -147,6 +147,82 @@ tests:
           errorMessage: "langfuse.aiFeatures.provider and langfuse.aiFeatures.model are required when langfuse.aiFeatures.inAppAgent.enabled is true"
         template: validations.yaml
 
+  - it: fails when a model is set without a provider, which silently does nothing
+    values:
+      - ../values.lint.yaml
+    set:
+      langfuse:
+        aiFeatures:
+          model: eu.anthropic.claude-opus-5
+    asserts:
+      - failedTemplate:
+          errorMessage: "langfuse.aiFeatures.provider is required when langfuse.aiFeatures.model is set. Without it the model is ignored and the AI features report as unconfigured."
+        template: validations.yaml
+
+  - it: fails when anthropic or openai has no API key
+    values:
+      - ../values.lint.yaml
+    set:
+      langfuse:
+        aiFeatures:
+          provider: anthropic
+          model: claude-opus-5
+    asserts:
+      - failedTemplate:
+          errorMessage: "langfuse.aiFeatures.apiKey is required for the anthropic and openai providers. Set apiKey.secretKeyRef, or apiKey.value."
+        template: validations.yaml
+
+  - it: fails when bedrock is given an API key it cannot use
+    values:
+      - ../values.lint.yaml
+    set:
+      langfuse:
+        aiFeatures:
+          provider: bedrock
+          model: eu.anthropic.claude-opus-5
+          apiKey:
+            value: sk-unused
+    asserts:
+      - failedTemplate:
+          errorMessage: "langfuse.aiFeatures.apiKey is not used by the bedrock provider, which authenticates through the AWS credential chain. Remove it, or switch provider."
+        template: validations.yaml
+
+  - it: fails on an unsupported provider
+    values:
+      - ../values.lint.yaml
+    set:
+      langfuse:
+        aiFeatures:
+          provider: gemini
+          model: gemini-3-pro
+    asserts:
+      - failedTemplate:
+          errorMessage: "langfuse.aiFeatures.provider must be one of bedrock, anthropic, or openai"
+        template: validations.yaml
+
+  - it: renders the API key by reference for anthropic
+    values:
+      - ../values.lint.yaml
+    set:
+      langfuse:
+        aiFeatures:
+          provider: anthropic
+          model: claude-opus-5
+          apiKey:
+            secretKeyRef:
+              name: my-secret
+              key: anthropic-key
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LANGFUSE_AI_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: my-secret
+                key: anthropic-key
+        template: worker/deployment.yaml
+
   - it: fails when a provider is set without a model
     values:
       - ../values.lint.yaml

--- a/charts/langfuse/values.yaml
+++ b/charts/langfuse/values.yaml
@@ -192,7 +192,7 @@ langfuse:
         # -- Point the worker's MCP calls at the in-cluster web Service and allow that Host on web. Sets LANGFUSE_MCP_BASE_URL, so the externally resolvable NEXTAUTH_URL is left alone; the worker also builds email and Slack links from it. Requires application version >= 4.25, unlike the rest of this block; on 4.24 the worker ignores it and falls back to NEXTAUTH_URL.
         useInternalWebUrl: false
       sandbox:
-        # -- LANGFUSE_IN_APP_AGENT_SANDBOX_PROVIDER. `lambda-microvm` is the only accepted value; leave empty for Langfuse tools only. The application also has a `dangerous-docker` provider, but it refuses to start unless NODE_ENV=development, so it is not usable here.
+        # -- LANGFUSE_IN_APP_AGENT_SANDBOX_PROVIDER. `lambda-microvm` is the only accepted value; leave empty for Langfuse tools only. The application also has a development-only `dangerous-docker` provider, which is not usable in a deployed instance.
         provider: ""
         # -- LANGFUSE_IN_APP_AGENT_SANDBOX_AWS_LAMBDA_MICROVM_IMAGE_IDENTIFIER
         imageIdentifier: ""

--- a/charts/langfuse/values.yaml
+++ b/charts/langfuse/values.yaml
@@ -192,7 +192,7 @@ langfuse:
         # -- Point the worker's MCP calls at the in-cluster web Service and allow that Host on web. Sets LANGFUSE_MCP_BASE_URL, so the externally resolvable NEXTAUTH_URL is left alone; the worker also builds email and Slack links from it. Requires application version >= 4.25, unlike the rest of this block; on 4.24 the worker ignores it and falls back to NEXTAUTH_URL.
         useInternalWebUrl: false
       sandbox:
-        # -- LANGFUSE_IN_APP_AGENT_SANDBOX_PROVIDER. Use `lambda-microvm` on AWS. Leave empty for Langfuse tools only.
+        # -- LANGFUSE_IN_APP_AGENT_SANDBOX_PROVIDER. `lambda-microvm` is the only accepted value; leave empty for Langfuse tools only. The application also has a `dangerous-docker` provider, but it refuses to start unless NODE_ENV=development, so it is not usable here.
         provider: ""
         # -- LANGFUSE_IN_APP_AGENT_SANDBOX_AWS_LAMBDA_MICROVM_IMAGE_IDENTIFIER
         imageIdentifier: ""

--- a/charts/langfuse/values.yaml
+++ b/charts/langfuse/values.yaml
@@ -189,7 +189,7 @@ langfuse:
       # -- Set to `true` to set LANGFUSE_IN_APP_AGENT_ENABLED on web and worker
       enabled: false
       mcp:
-        # -- Point the worker's MCP calls at the in-cluster web Service and allow that Host on web. Sets LANGFUSE_MCP_BASE_URL, so the externally resolvable NEXTAUTH_URL is left alone; the worker also builds email and Slack links from it. Requires a Langfuse version that supports LANGFUSE_MCP_BASE_URL.
+        # -- Point the worker's MCP calls at the in-cluster web Service and allow that Host on web. Sets LANGFUSE_MCP_BASE_URL, so the externally resolvable NEXTAUTH_URL is left alone; the worker also builds email and Slack links from it. Requires application version >= 4.25, unlike the rest of this block; on 4.24 the worker ignores it and falls back to NEXTAUTH_URL.
         useInternalWebUrl: false
       sandbox:
         # -- LANGFUSE_IN_APP_AGENT_SANDBOX_PROVIDER. Use `lambda-microvm` on AWS. Leave empty for Langfuse tools only.

--- a/charts/langfuse/values.yaml
+++ b/charts/langfuse/values.yaml
@@ -161,6 +161,48 @@ langfuse:
   # -- Allows additional lifecycle hooks to be added to all langfuse deployments
   extraLifecycle: {}
 
+  # -- Langfuse AI features: the in-app agent and Ask AI. One instance-wide Langfuse AI model powers both. Requires application version >= 4.24. Helm does not create AWS Lambda MicroVM resources; pass ARNs from Terraform or a manual AWS setup. See https://langfuse.com/self-hosting/configuration/langfuse-assistant
+  aiFeatures:
+    # -- LANGFUSE_AI_PROVIDER: bedrock, anthropic, or openai. Required to enable the AI features; there is no default.
+    provider: ""
+    # -- LANGFUSE_AI_MODEL. Required whenever provider is set.
+    model: ""
+    # -- LANGFUSE_AI_SMALL_MODEL for supplementary calls such as conversation titles
+    smallModel: ""
+    # -- LANGFUSE_AI_API_KEY (anthropic and openai). Prefer secretKeyRef.
+    apiKey:
+      value: ""
+      secretKeyRef:
+        name: ""
+        key: ""
+    # -- LANGFUSE_AI_BASE_URL. For openai, include `/v1`.
+    baseUrl: ""
+    # -- LANGFUSE_AI_EXTRA_HEADERS as a JSON object string
+    extraHeaders: ""
+    # -- Set LANGFUSE_AI_USE_RESPONSES_API=true for the OpenAI Responses API
+    useResponsesApi: false
+    # -- LANGFUSE_AI_AWS_BEDROCK_REGION
+    bedrockRegion: ""
+    # -- LANGFUSE_AI_FEATURES_PROJECT_ID for tracing AI feature runs on this instance
+    projectId: ""
+    inAppAgent:
+      # -- Set to `true` to set LANGFUSE_IN_APP_AGENT_ENABLED on web and worker
+      enabled: false
+      mcp:
+        # -- Point the worker's MCP calls at the in-cluster web Service and allow that Host on web. Sets LANGFUSE_MCP_BASE_URL, so the externally resolvable NEXTAUTH_URL is left alone; the worker also builds email and Slack links from it. Requires a Langfuse version that supports LANGFUSE_MCP_BASE_URL.
+        useInternalWebUrl: false
+      sandbox:
+        # -- LANGFUSE_IN_APP_AGENT_SANDBOX_PROVIDER. Use `lambda-microvm` on AWS. Leave empty for Langfuse tools only.
+        provider: ""
+        # -- LANGFUSE_IN_APP_AGENT_SANDBOX_AWS_LAMBDA_MICROVM_IMAGE_IDENTIFIER
+        imageIdentifier: ""
+        # -- LANGFUSE_IN_APP_AGENT_SANDBOX_AWS_LAMBDA_MICROVM_EXECUTION_ROLE_ARN
+        executionRoleArn: ""
+        # -- LANGFUSE_IN_APP_AGENT_SANDBOX_AWS_LAMBDA_MICROVM_REGION
+        region: ""
+        # -- LANGFUSE_IN_APP_AGENT_SANDBOX_AWS_LAMBDA_MICROVM_EGRESS_NETWORK_CONNECTOR_ARN. Required with the lambda-microvm provider: without it AWS attaches its default INTERNET_EGRESS connector and sandboxed code reaches the public internet.
+        egressNetworkConnectorArn: ""
+
   # Web deployment configuration
   web:
     image:

--- a/charts/langfuse/values.yaml
+++ b/charts/langfuse/values.yaml
@@ -163,13 +163,13 @@ langfuse:
 
   # -- Langfuse AI features: the in-app agent and Ask AI. One instance-wide Langfuse AI model powers both. Requires application version >= 4.24. Helm does not create AWS Lambda MicroVM resources; pass ARNs from Terraform or a manual AWS setup. See https://langfuse.com/self-hosting/configuration/langfuse-assistant
   aiFeatures:
-    # -- LANGFUSE_AI_PROVIDER: bedrock, anthropic, or openai. Required to enable the AI features; there is no default.
+    # -- LANGFUSE_AI_PROVIDER: bedrock, anthropic, or openai. Required to enable the AI features; there is no default. Must be set together with model.
     provider: ""
     # -- LANGFUSE_AI_MODEL. Required whenever provider is set.
     model: ""
     # -- LANGFUSE_AI_SMALL_MODEL for supplementary calls such as conversation titles
     smallModel: ""
-    # -- LANGFUSE_AI_API_KEY (anthropic and openai). Prefer secretKeyRef.
+    # -- LANGFUSE_AI_API_KEY. Required for anthropic and openai; rejected for bedrock, which authenticates through the AWS credential chain. Prefer secretKeyRef.
     apiKey:
       value: ""
       secretKeyRef:


### PR DESCRIPTION
https://linear.app/clickhouse/issue/LFE-15741/add-helm-values-and-aws-terraform-module-for-the-assistant-sandbox

## Summary

Adds `langfuse.aiFeatures.*` so operators do not have to assemble the model, in-app agent and sandbox environment by hand in `additionalEnv`. Chart version `2.1.0`; requires Langfuse `>= 4.24` via `langfuse.image.tag`. Default `appVersion` is unchanged.

```yaml
langfuse:
  aiFeatures:
    provider: bedrock
    model: eu.anthropic.claude-opus-5
    bedrockRegion: eu-west-1
    inAppAgent:
      enabled: true
      mcp:
        useInternalWebUrl: true # this one value needs >= 4.25, see below
      sandbox:
        provider: lambda-microvm
        imageIdentifier: arn:aws:lambda:...:microvm-image:...
        executionRoleArn: arn:aws:iam::...:role/...
        region: eu-west-1
        egressNetworkConnectorArn: arn:aws:lambda:...:network-connector:...
```

Model variables go to web and worker — both call the model, web for Ask AI and conversation titles, worker for agent runs. Sandbox variables are worker-only. Helm creates no AWS Lambda MicroVM resources; pass ARNs from [langfuse-terraform-aws](https://github.com/langfuse/langfuse-terraform-aws/pull/77) or a manual setup.

## Named for the AI features, not the Assistant

The same instance-wide model backs both the in-app agent and Ask AI, so naming the block after one of them would be wrong. The product name is also not settled, and chart values are expensive to rename once released — they live in users' `values.yaml`, in Git and in GitOps manifests, so a later rename needs alias logic, a deprecation window and probably a chart major. Doing it before `2.1.0` ships costs nothing. Agent-specific settings nest under `aiFeatures.inAppAgent`, every key names the environment variable it sets, and the names match the Terraform module's variables.

## Rejecting half-configured values

Rendering was permissive in four ways that each produced a deployment that looked configured while the app reported the AI features unconfigured. All four are now rejected at template time, with a message naming the fix:

| Input | Was | Now |
| --- | --- | --- |
| `anthropic`/`openai` with no `apiKey` | emitted provider + model, no credential | rejected |
| `model` with no `provider` | emitted `LANGFUSE_AI_MODEL` alone, which the app ignores | rejected |
| `bedrock` with an `apiKey` | emitted an unused `LANGFUSE_AI_API_KEY` | rejected |
| unsupported `provider` | rendered, failed later at worker boot | rejected |
| `sandbox.provider` other than `lambda-microvm` | rendered; `dangerous-docker` is development-only and unusable in a deployed instance | rejected |

The first is the same gap [langfuse-terraform-aws#77](https://github.com/langfuse/langfuse-terraform-aws/pull/77) closed; the two repos now agree on what a valid provider configuration looks like.

## User env takes precedence

The in-cluster MCP variables render *before* `additionalEnv`, so a user-supplied value wins. `commonEnv` and `agentSandboxEnv` were already ordered that way; the MCP include was the exception. Container env is last-write-wins, so this was the difference between a user override working and being silently ignored.

## Two fixes to the earlier shape

**`egressNetworkConnectorArn` is now required** with the `lambda-microvm` provider. Without it AWS attaches its default `INTERNET_EGRESS` connector, so a configuration that looked sandboxed handed user-provided code the public internet.

**The in-cluster MCP option no longer overrides `NEXTAUTH_URL`.** It sets `LANGFUSE_MCP_BASE_URL` instead. The worker also builds links for users out of `NEXTAUTH_URL` — batch export completion emails, Slack notifications, blob storage integration settings, usage threshold emails — so pointing it at a cluster-internal Service made every one of those links unreachable. Langfuse Cloud was never affected: it uses one public `NEXTAUTH_URL` on web and worker and reaches MCP over it.

`LANGFUSE_MCP_BASE_URL` was added in https://github.com/langfuse/langfuse/pull/16837 and **shipped in v4.25.0**, so there is no release-ordering constraint left. Note the two different floors: the `aiFeatures` block needs `>= 4.24`, and only `inAppAgent.mcp.useInternalWebUrl` needs `>= 4.25`. On 4.24 that one value is a no-op — the worker ignores the unknown variable and falls back to `NEXTAUTH_URL` — so the chart is fully usable on 4.24 as long as the toggle stays off.

## Test plan

- [x] `helm unittest charts/langfuse/` — 110 tests, 19 suites passing
- [x] `helm lint` with `values.lint.yaml`
- [x] `helm-docs` regenerated and committed
- [x] `helm template` confirms the worker keeps the public `NEXTAUTH_URL` while `LANGFUSE_MCP_BASE_URL` carries the in-cluster address, and that the sandbox variables reach the worker only
- [x] Defaults emit no AI feature environment

`tests/ai_features_test.yaml` covers 13 cases: env placement across web and worker, the API key rendering by reference, and each of the rejections above plus the egress-connector requirement and the MCP overlay leaving `NEXTAUTH_URL` alone.

## Companions

- Terraform: https://github.com/langfuse/langfuse-terraform-aws/pull/77
- MCP endpoint: https://github.com/langfuse/langfuse/pull/16837 — merged, shipped in `v4.25.0`
- Docs: https://github.com/langfuse/langfuse-docs/pull/3619 — still recommends overriding `NEXTAUTH_URL` on the worker and needs the same correction

🤖 Generated with [Claude Code](https://claude.com/claude-code)



