### PR TITLE
feat: add support for Gateway API HTTPRoute configuration and validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -576,6 +576,54 @@ langfuse:
               number: 8080
 ```
 
+##### Enable the Gateway API (HTTPRoute)
+
+As an alternative to `langfuse.ingress`, the chart can render a Gateway API `HTTPRoute`. This requires the [Gateway API CRDs](https://gateway-api.sigs.k8s.io/guides/) and a Gateway controller, plus an existing `Gateway` for the route to attach to.
+
+```yaml
+[...]
+langfuse:
+  httpRoute:
+    enabled: true
+    parentRefs:
+      - name: my-gateway
+        namespace: gateway-system
+        sectionName: https
+    hostnames:
+      - langfuse.your-host.com
+```
+
+When `rules` is omitted, all traffic on the listed hostnames is routed to the Langfuse web service. Provide `rules` for advanced routing — any rule without `backendRefs` still falls back to the Langfuse web service:
+
+```yaml
+[...]
+langfuse:
+  httpRoute:
+    enabled: true
+    parentRefs:
+      - name: my-gateway
+    hostnames:
+      - langfuse.example.com
+    rules:
+      # Custom backend for a specific path
+      - matches:
+          - path:
+              type: PathPrefix
+              value: /api/webhook
+        backendRefs:
+          - name: webhook-service
+            port: 8080
+      # Everything else goes to the Langfuse web service
+      - matches:
+          - path:
+              type: PathPrefix
+              value: /
+        timeouts:
+          request: 60s
+```
+
+Set `langfuse.httpRoute.apiVersion` to pin `gateway.networking.k8s.io/v1beta1` on older clusters; otherwise the version is detected from the cluster. Set `langfuse.httpRoute.crdCheck: false` to skip the CRD preflight when rendering offline (`helm template`, GitOps diffs).
+
 #### Custom Storage Class Definition
 
 The Langfuse chart supports configuring storage classes for all persistent volumes in the deployment. You can configure storage classes in two ways:

--- a/charts/langfuse/README.md
+++ b/charts/langfuse/README.md
@@ -87,6 +87,14 @@ Open source LLM engineering platform - LLM observability, metrics, evaluations, 
 | langfuse.features.experimentalFeaturesEnabled | bool | `false` | Enable experimental features |
 | langfuse.features.signUpDisabled | bool | `false` | Disable public sign up |
 | langfuse.features.telemetryEnabled | bool | `true` | Whether or not to report basic usage statistics to a centralized server. |
+| langfuse.httpRoute.additionalLabels | object | `{}` | Additional labels for the HTTPRoute resource |
+| langfuse.httpRoute.annotations | object | `{}` | Annotations for the HTTPRoute resource |
+| langfuse.httpRoute.apiVersion | string | `""` | API version of the HTTPRoute resource. Auto-detected from the cluster when empty |
+| langfuse.httpRoute.crdCheck | bool | `true` | Set to `false` to skip the Gateway API CRD preflight check (offline rendering, GitOps diff) |
+| langfuse.httpRoute.enabled | bool | `false` | Set to `true` to enable the Gateway API HTTPRoute resource |
+| langfuse.httpRoute.hostnames | list | `[]` | The hostnames matched by this route |
+| langfuse.httpRoute.parentRefs | list | `[]` | The Gateways this route attaches to. Required when `enabled` is `true` |
+| langfuse.httpRoute.rules | list | `[]` | Routing rules. Rules without `backendRefs` are pointed at the langfuse web service. Defaults to a single `/` prefix rule when empty |
 | langfuse.image.pullPolicy | string | `"Always"` | The pull policy to use for all langfuse deployments. Can be overridden by the individual deployments. |
 | langfuse.image.pullSecrets | list | `[]` | The pull secrets to use for all langfuse deployments. Can be overridden by the individual deployments. |
 | langfuse.image.tag | string | `nil` | The image tag to use for all langfuse deployments. Can be overridden by the individual deployments. Falls back to appVersion if not set. |

--- a/charts/langfuse/templates/_helpers.tpl
+++ b/charts/langfuse/templates/_helpers.tpl
@@ -62,6 +62,23 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
+API version for the Gateway API HTTPRoute. Prefers an explicit override, then
+whatever the cluster registers. Offline rendering (helm template, unit tests)
+has no discovery, so fall back to the GA version.
+*/}}
+{{- define "langfuse.httpRoute.apiVersion" -}}
+{{- if .Values.langfuse.httpRoute.apiVersion -}}
+{{- .Values.langfuse.httpRoute.apiVersion -}}
+{{- else if .Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1/HTTPRoute" -}}
+gateway.networking.k8s.io/v1
+{{- else if .Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1beta1/HTTPRoute" -}}
+gateway.networking.k8s.io/v1beta1
+{{- else -}}
+gateway.networking.k8s.io/v1
+{{- end -}}
+{{- end }}
+
+{{/*
 Fullname of an aliased sub-chart, computed the way the sub-chart's own
 fullname helper does (postgres, valkey, and seaweedfs all share the standard
 pattern, with the dependency alias as the chart name). This is what the

--- a/charts/langfuse/templates/httproute.yaml
+++ b/charts/langfuse/templates/httproute.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.langfuse.httpRoute.enabled -}}
+{{- $port := .Values.langfuse.web.service.externalPort | default .Values.langfuse.web.service.port -}}
+{{- $defaultBackendRefs := list (dict "name" (printf "%s-web" (include "langfuse.fullname" .)) "port" $port) -}}
+{{- $rules := .Values.langfuse.httpRoute.rules | default (list (dict "matches" (list (dict "path" (dict "type" "PathPrefix" "value" "/"))))) -}}
+apiVersion: {{ include "langfuse.httpRoute.apiVersion" . }}
+kind: HTTPRoute
+metadata:
+  name: {{ include "langfuse.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "langfuse.labels" . | nindent 4 }}
+    {{- with .Values.langfuse.httpRoute.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.langfuse.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- toYaml .Values.langfuse.httpRoute.parentRefs | nindent 4 }}
+  {{- with .Values.langfuse.httpRoute.hostnames }}
+  hostnames:
+    {{- range . }}
+    - {{ . | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range $rules }}
+    {{- $rest := omit . "backendRefs" }}
+    - backendRefs:
+        {{- toYaml (.backendRefs | default $defaultBackendRefs) | nindent 8 }}
+      {{- with $rest }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/langfuse/templates/validations.yaml
+++ b/charts/langfuse/templates/validations.yaml
@@ -92,6 +92,18 @@ what you are doing.
 {{- end -}}
 {{- end -}}
 
+# Validate Gateway API settings
+{{- if $.Values.langfuse.httpRoute.enabled -}}
+{{- if eq (len $.Values.langfuse.httpRoute.parentRefs) 0 -}}
+    {{- fail "langfuse.httpRoute.parentRefs must list at least one Gateway when langfuse.httpRoute.enabled is true: an HTTPRoute with no parent attaches to nothing and silently receives no traffic." -}}
+{{- end -}}
+{{- if and $.Values.langfuse.httpRoute.crdCheck (not $.Values.langfuse.httpRoute.apiVersion) -}}
+{{- if not (or ($.Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1/HTTPRoute") ($.Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1beta1/HTTPRoute")) -}}
+    {{- fail "Gateway API CRDs not found (gateway.networking.k8s.io HTTPRoute). Install the Gateway API CRDs and a Gateway controller before enabling langfuse.httpRoute. To skip this check for offline rendering (helm template / GitOps diff), set langfuse.httpRoute.crdCheck=false or pass --api-versions gateway.networking.k8s.io/v1/HTTPRoute." -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
 # Validate ClickHouse settings
 {{- if and (not $.Values.clickhouse.deploy) (not $.Values.clickhouse.host) (not (include "langfuse.getEnvVar" (dict "env" $.Values.langfuse.additionalEnv "name" "CLICKHOUSE_URL"))) -}}
     {{- fail "ClickHouse host must be configured when using an external ClickHouse instance. Set clickhouse.host to continue." -}}

--- a/charts/langfuse/tests/httproute-validation_test.yaml
+++ b/charts/langfuse/tests/httproute-validation_test.yaml
@@ -1,0 +1,59 @@
+suite: test Gateway API HTTPRoute validations
+templates:
+  - validations.yaml
+tests:
+  - it: should fail when parentRefs is empty
+    values:
+      - ../values.lint.yaml
+    set:
+      langfuse.httpRoute.enabled: true
+      langfuse.httpRoute.crdCheck: false
+    asserts:
+      - failedTemplate:
+          errorPattern: "langfuse.httpRoute.parentRefs must list at least one Gateway"
+
+  - it: should fail when the Gateway API CRDs are absent and crdCheck is enabled
+    values:
+      - ../values.lint.yaml
+    set:
+      langfuse.httpRoute.enabled: true
+      langfuse.httpRoute.crdCheck: true
+      langfuse.httpRoute.parentRefs:
+        - name: my-gateway
+    asserts:
+      - failedTemplate:
+          errorPattern: "Gateway API CRDs not found"
+
+  - it: should pass when the Gateway API CRDs are registered
+    values:
+      - ../values.lint.yaml
+    set:
+      langfuse.httpRoute.enabled: true
+      langfuse.httpRoute.crdCheck: true
+      langfuse.httpRoute.parentRefs:
+        - name: my-gateway
+    capabilities:
+      apiVersions:
+        - gateway.networking.k8s.io/v1/HTTPRoute
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should skip the CRD check when crdCheck is disabled
+    values:
+      - ../values.lint.yaml
+    set:
+      langfuse.httpRoute.enabled: true
+      langfuse.httpRoute.crdCheck: false
+      langfuse.httpRoute.parentRefs:
+        - name: my-gateway
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should skip all checks when httpRoute is disabled
+    values:
+      - ../values.lint.yaml
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/langfuse/tests/httproute_test.yaml
+++ b/charts/langfuse/tests/httproute_test.yaml
@@ -1,0 +1,156 @@
+suite: test Gateway API HTTPRoute functionality
+templates:
+  - httproute.yaml
+tests:
+  - it: should not render an HTTPRoute by default
+    values:
+      - ../values.lint.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render an HTTPRoute with the default rule and backend
+    values:
+      - ../values.lint.yaml
+    set:
+      langfuse.httpRoute.enabled: true
+      langfuse.httpRoute.crdCheck: false
+      langfuse.httpRoute.parentRefs:
+        - name: my-gateway
+          namespace: gateway-system
+          sectionName: https
+      langfuse.httpRoute.hostnames:
+        - langfuse.example.com
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: HTTPRoute
+      - isAPIVersion:
+          of: gateway.networking.k8s.io/v1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-langfuse
+      - equal:
+          path: spec.parentRefs[0].name
+          value: my-gateway
+      - equal:
+          path: spec.parentRefs[0].namespace
+          value: gateway-system
+      - equal:
+          path: spec.parentRefs[0].sectionName
+          value: https
+      - equal:
+          path: spec.hostnames[0]
+          value: langfuse.example.com
+      - equal:
+          path: spec.rules[0].matches[0].path.type
+          value: PathPrefix
+      - equal:
+          path: spec.rules[0].matches[0].path.value
+          value: /
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: RELEASE-NAME-langfuse-web
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 3000
+
+  - it: should use the v1beta1 API when only that version is registered
+    values:
+      - ../values.lint.yaml
+    set:
+      langfuse.httpRoute.enabled: true
+      langfuse.httpRoute.parentRefs:
+        - name: my-gateway
+    capabilities:
+      apiVersions:
+        - gateway.networking.k8s.io/v1beta1/HTTPRoute
+    asserts:
+      - isAPIVersion:
+          of: gateway.networking.k8s.io/v1beta1
+
+  - it: should honor an explicit apiVersion override
+    values:
+      - ../values.lint.yaml
+    set:
+      langfuse.httpRoute.enabled: true
+      langfuse.httpRoute.apiVersion: gateway.networking.k8s.io/v1beta1
+      langfuse.httpRoute.parentRefs:
+        - name: my-gateway
+    asserts:
+      - isAPIVersion:
+          of: gateway.networking.k8s.io/v1beta1
+
+  - it: should use the service externalPort for the default backend
+    values:
+      - ../values.lint.yaml
+    set:
+      langfuse.httpRoute.enabled: true
+      langfuse.httpRoute.crdCheck: false
+      langfuse.web.service.externalPort: 8080
+      langfuse.httpRoute.parentRefs:
+        - name: my-gateway
+    asserts:
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 8080
+
+  - it: should render custom rules and keep explicit backendRefs
+    values:
+      - ../values.lint.yaml
+    set:
+      langfuse.httpRoute.enabled: true
+      langfuse.httpRoute.crdCheck: false
+      langfuse.httpRoute.parentRefs:
+        - name: my-gateway
+      langfuse.httpRoute.rules:
+        - matches:
+            - path:
+                type: PathPrefix
+                value: /api
+          timeouts:
+            request: 60s
+        - matches:
+            - path:
+                type: PathPrefix
+                value: /legacy
+          backendRefs:
+            - name: legacy-web
+              port: 80
+    asserts:
+      - equal:
+          path: spec.rules[0].matches[0].path.value
+          value: /api
+      - equal:
+          path: spec.rules[0].timeouts.request
+          value: 60s
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: RELEASE-NAME-langfuse-web
+      - equal:
+          path: spec.rules[1].backendRefs[0].name
+          value: legacy-web
+      - equal:
+          path: spec.rules[1].backendRefs[0].port
+          value: 80
+
+  - it: should render additional labels and annotations
+    values:
+      - ../values.lint.yaml
+    set:
+      langfuse.httpRoute.enabled: true
+      langfuse.httpRoute.crdCheck: false
+      langfuse.httpRoute.parentRefs:
+        - name: my-gateway
+      langfuse.httpRoute.additionalLabels:
+        team: platform
+      langfuse.httpRoute.annotations:
+        example.com/owner: platform
+    asserts:
+      - equal:
+          path: metadata.labels.team
+          value: platform
+      - equal:
+          path: metadata.annotations["example.com/owner"]
+          value: platform

--- a/charts/langfuse/values.yaml
+++ b/charts/langfuse/values.yaml
@@ -105,6 +105,41 @@ langfuse:
       # -- The name of the secret to use for TLS Key
       secretName: ""
 
+  # Kubernetes Gateway API. Alternative to `langfuse.ingress`; requires the
+  # Gateway API CRDs and a Gateway that this route attaches to.
+  httpRoute:
+    # -- Set to `true` to enable the Gateway API HTTPRoute resource
+    enabled: false
+    # -- Set to `false` to skip the Gateway API CRD preflight check (offline rendering, GitOps diff)
+    crdCheck: true
+    # -- Additional labels for the HTTPRoute resource
+    additionalLabels: {}
+    # -- Annotations for the HTTPRoute resource
+    annotations: {}
+    # -- API version of the HTTPRoute resource. Auto-detected from the cluster when empty
+    apiVersion: ""
+    # -- The Gateways this route attaches to. Required when `enabled` is `true`
+    parentRefs: []
+    # Example:
+    # - name: my-gateway
+    #   namespace: gateway-system
+    #   sectionName: https
+
+    # -- The hostnames matched by this route
+    hostnames: []
+    # Example:
+    # - "langfuse.example.com"
+
+    # -- Routing rules. Rules without `backendRefs` are pointed at the langfuse web service. Defaults to a single `/` prefix rule when empty
+    rules: []
+    # Example:
+    # - matches:
+    #     - path:
+    #         type: PathPrefix
+    #         value: /
+    #   timeouts:
+    #     request: 60s
+
   # -- Pod security context for all langfuse deployments
   podSecurityContext: {}
   # -- Security context for all langfuse deployments


### PR DESCRIPTION
Adds support for the Kubernetes Gateway API as an alternative to the existing Ingress resource. The chart can now render an HTTPRoute that attaches to an existing Gateway.

Ingress support is untouched, this is purely additive and disabled by default.

The Gateway API is the successor to Ingress and is now GA (gateway.networking.k8s.io/v1). Users running Envoy Gateway, Istio, Cilium, NGINX Gateway Fabric, etc