### PR TITLE
feat(clickhouse): expose KeeperCluster settings

### DIFF
--- a/charts/langfuse/README.md
+++ b/charts/langfuse/README.md
@@ -60,6 +60,7 @@ Open source LLM engineering platform - LLM observability, metrics, evaluations, 
 | clickhouse.keeper.priorityClassName | string | `""` | PriorityClass for Keeper pods. |
 | clickhouse.keeper.replicas | int | `3` | Keeper replica count (must be odd: 1, 3, or 5). Use 3 for production HA. |
 | clickhouse.keeper.resources | object | `{"limits":{"memory":"1Gi"},"requests":{"cpu":"250m","memory":"256Mi"}}` | CPU/memory requests and limits for Keeper pods. |
+| clickhouse.keeper.settings | object | `{}` | Extra Keeper settings applied under the KeeperCluster `spec.settings` field. |
 | clickhouse.keeper.storage.accessModes[0] | string | `"ReadWriteOnce"` |  |
 | clickhouse.keeper.storage.className | string | `""` | StorageClass for Keeper PVCs. Leave empty to use the cluster default. |
 | clickhouse.keeper.storage.size | string | `"20Gi"` | Persistent volume size for each Keeper pod. |

--- a/charts/langfuse/templates/clickhouse/keeper.yaml
+++ b/charts/langfuse/templates/clickhouse/keeper.yaml
@@ -25,6 +25,10 @@ spec:
     resources:
       {{- toYaml . | nindent 6 }}
     {{- end }}
+  {{- with .Values.clickhouse.keeper.settings }}
+  settings:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- if or .Values.clickhouse.keeper.nodeSelector .Values.clickhouse.keeper.tolerations .Values.clickhouse.keeper.affinity .Values.clickhouse.keeper.priorityClassName }}
   podTemplate:
     {{- with .Values.clickhouse.keeper.nodeSelector }}

--- a/charts/langfuse/tests/clickhouse-resources_test.yaml
+++ b/charts/langfuse/tests/clickhouse-resources_test.yaml
@@ -53,6 +53,19 @@ tests:
           value: 16Gi
         template: clickhouse/cluster.yaml
 
+  - it: should render extra KeeperCluster settings
+    values:
+      - ../values.lint.yaml
+    set:
+      clickhouse.keeper.settings:
+        logger:
+          level: warning
+    asserts:
+      - equal:
+          path: spec.settings.logger.level
+          value: warning
+        template: clickhouse/keeper.yaml
+
   - it: should always emit the CRD-required keeperClusterRef on the ClickHouseCluster
     values:
       - ../values.lint.yaml

--- a/charts/langfuse/values.yaml
+++ b/charts/langfuse/values.yaml
@@ -841,6 +841,8 @@ clickhouse:
     affinity: {}
     # -- PriorityClass for Keeper pods.
     priorityClassName: ""
+    # -- Extra Keeper settings applied under the KeeperCluster `spec.settings` field.
+    settings: {}
 
 # S3 / Object Storage Configuration
 # Deploys SeaweedFS in allInOne mode via the seaweedfs/seaweedfs sub-chart (image `chrislusf/seaweedfs`).


### PR DESCRIPTION
## Summary

Expose `clickhouse.keeper.settings` as a pass-through to `KeeperCluster.spec.settings`, matching the existing `clickhouse.cluster.settings` pattern.

This allows users to configure supported operator settings such as Keeper logger level declaratively without patch jobs or chart forks.

```yaml
clickhouse:
  keeper:
    settings:
      logger:
        level: warning
```

## Validation

- `helm lint charts/langfuse -f charts/langfuse/values.lint.yaml`
- `helm unittest charts/langfuse` — 19 suites, 111 tests passed
- rendered `KeeperCluster.spec.settings.logger.level` is `warning`
- regenerated chart README with helm-docs 1.14.2
- `git diff --check`