### PR TITLE
docs: require UTC for external databases

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,9 @@ See our [self-hosting docs](https://langfuse.com/self-hosting/infrastructure/blo
 
 #### Examples
 
+> [!IMPORTANT]
+> External PostgreSQL and ClickHouse instances must use UTC. See the [timezone troubleshooting guide](https://langfuse.com/faq/all/self-hosting-timezone-errors) for verification steps and fixes.
+
 ##### With an external Postgres server
 
 ```yaml


### PR DESCRIPTION
## Summary

- document that external PostgreSQL and ClickHouse instances must use UTC
- link to the Langfuse timezone troubleshooting guide for verification and fixes

## Checks

- `git diff --check`