### PR TITLE
feat: expose version-probe resources on the ClickHouseCluster

### DIFF
--- a/charts/langfuse/README.md
+++ b/charts/langfuse/README.md
@@ -47,6 +47,7 @@ Open source LLM engineering platform - LLM observability, metrics, evaluations, 
 | clickhouse.cluster.storage.className | string | `""` | StorageClass for ClickHouse PVCs. Leave empty to use the cluster default. |
 | clickhouse.cluster.storage.size | string | `"100Gi"` | Persistent volume size for each ClickHouse pod. |
 | clickhouse.cluster.tolerations | list | `[]` | Tolerations for ClickHouse pods. |
+| clickhouse.cluster.versionProbeResources | object | `{"limits":{"memory":"512Mi"},"requests":{"cpu":"100m","memory":"256Mi"}}` | CPU/memory for the operator's version-probe Job (`clickhouse local`, runs before the server StatefulSet is created). The operator's own 256Mi default OOMKills on recent clickhouse-server images and stalls reconcile with `VersionProbeFailed`. Set to `null` to fall back to the operator default. |
 | clickhouse.crdCheck | bool | `true` | Require ClickHouse operator CRDs when deploy is true. Disable for offline helm template/GitOps diffs (or pass `--api-versions clickhouse.com/v1alpha1/ClickHouseCluster`). |
 | clickhouse.database | string | `"default"` | ClickHouse database name Langfuse connects to. |
 | clickhouse.deploy | bool | `true` | Deploy ClickHouse (ClickHouseCluster + KeeperCluster CRs) via the operator. Disable to use an external or self-managed ClickHouse. |

--- a/charts/langfuse/templates/clickhouse/cluster.yaml
+++ b/charts/langfuse/templates/clickhouse/cluster.yaml
@@ -29,6 +29,17 @@ spec:
     resources:
       {{- toYaml . | nindent 6 }}
     {{- end }}
+  {{- /* The operator merges this onto its own probe Job by container name (strategic merge patch), so only name + resources are needed. */}}
+  {{- with .Values.clickhouse.cluster.versionProbeResources }}
+  versionProbeTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: version-probe
+              resources:
+                {{- toYaml . | nindent 16 }}
+  {{- end }}
   {{- if or .Values.clickhouse.cluster.nodeSelector .Values.clickhouse.cluster.tolerations .Values.clickhouse.cluster.affinity .Values.clickhouse.cluster.priorityClassName }}
   podTemplate:
     {{- with .Values.clickhouse.cluster.nodeSelector }}

--- a/charts/langfuse/tests/clickhouse-resources_test.yaml
+++ b/charts/langfuse/tests/clickhouse-resources_test.yaml
@@ -53,6 +53,48 @@ tests:
           value: 16Gi
         template: clickhouse/cluster.yaml
 
+  - it: should ship non-empty default resources on the version-probe Job
+    values:
+      - ../values.lint.yaml
+    asserts:
+      - equal:
+          path: spec.versionProbeTemplate.spec.template.spec.containers[0].name
+          value: version-probe
+        template: clickhouse/cluster.yaml
+      - equal:
+          path: spec.versionProbeTemplate.spec.template.spec.containers[0].resources.requests.memory
+          value: 256Mi
+        template: clickhouse/cluster.yaml
+      - equal:
+          path: spec.versionProbeTemplate.spec.template.spec.containers[0].resources.limits.memory
+          value: 512Mi
+        template: clickhouse/cluster.yaml
+
+  - it: should allow overriding the version-probe resources
+    values:
+      - ../values.lint.yaml
+    set:
+      clickhouse.cluster.versionProbeResources:
+        requests:
+          memory: 2Gi
+        limits:
+          memory: 8Gi
+    asserts:
+      - equal:
+          path: spec.versionProbeTemplate.spec.template.spec.containers[0].resources.limits.memory
+          value: 8Gi
+        template: clickhouse/cluster.yaml
+
+  - it: should omit versionProbeTemplate when versionProbeResources is null
+    values:
+      - ../values.lint.yaml
+    set:
+      clickhouse.cluster.versionProbeResources: null
+    asserts:
+      - notExists:
+          path: spec.versionProbeTemplate
+        template: clickhouse/cluster.yaml
+
   - it: should always emit the CRD-required keeperClusterRef on the ClickHouseCluster
     values:
       - ../values.lint.yaml

--- a/charts/langfuse/values.yaml
+++ b/charts/langfuse/values.yaml
@@ -796,6 +796,13 @@ clickhouse:
         memory: 2Gi
       limits:
         memory: 4Gi
+    # -- CPU/memory for the operator's version-probe Job (`clickhouse local`, runs before the server StatefulSet is created). The operator's own 256Mi default OOMKills on recent clickhouse-server images and stalls reconcile with `VersionProbeFailed`. Set to `null` to fall back to the operator default.
+    versionProbeResources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        memory: 512Mi
     # -- Node selector for ClickHouse pods.
     nodeSelector: {}
     # -- Tolerations for ClickHouse pods.


### PR DESCRIPTION
Closes #418.

## What

Adds `clickhouse.cluster.versionProbeResources`, rendered on the `ClickHouseCluster` CR as `spec.versionProbeTemplate.spec.template.spec.containers` with a single `version-probe` container carrying only `name` and `resources`. The operator merges the template onto its own probe Job by container name (strategic merge patch), so no image or command needs to be repeated.

## Why

The operator's version-probe Job runs with a 256Mi memory limit and `backoffLimit: 0` in v0.0.7, which OOMKills `clickhouse local` on recent server images (reproduced with the chart's default `26.4`). The CR then reports `VersionProbeFailed`, reconcile stalls before the server StatefulSet is created, and `langfuse-web` crashloops. The CRD supports `versionProbeTemplate` (ClickHouse/clickhouse-operator#153), but the chart exposed no way to set it. See #418 for full details.

## Notes

- Ships non-empty defaults (requests 100m CPU / 256Mi, memory limit 512Mi, no CPU limit), following the precedent of `clickhouse.cluster.resources` ("non-empty defaults avoid the operator's ~1Gi fallback that OOMs under load"). Measured on the 26.4 image, the arm64 probe peaks just above 288Mi (details in the comment below), so 512Mi covers both architectures with headroom. Happy to make it opt-in (default `null`) instead if you'd rather not change rendered output for existing users.
- Setting the value to `null` omits the block entirely and falls back to the operator default. An empty map `{}` would merge with the chart defaults, so `null` is the documented off switch.
- Tests: three new helm-unittest cases (default emitted, override respected, `null` omits the block); the full suite passes 113/113. `helm lint` passes and the README was regenerated with helm-docs 1.14.2 to keep the validate workflow green.

